### PR TITLE
Add sourceRegex option to extract source names from measure names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ options under the top-level `librato` hash:
             measurements. This should be unique for each statsd
             process.
 
+* `sourceRegex`: An optional JavaScript regular expression to extract
+                 the source name from the measurement name. The first
+                 capturing group of the regex is used as the source name,
+                 and everything not matched will be the measurement name.
+
+                 Examples formats:
+
+                 "SOURCE.MEASURE" => /^([^\.]+)\./
+                 "MEASURE.SOURCE" => /\.([^\.]+)$/
+                 "server.SOURCE.MEASURE" => /^server\.([^\.]+)\./
+
 * `snapTime`: Measurement timestamps are snapped to this interval
               (specified in seconds). This makes it easier to align
               measurements sent from multiple statsd instances on a

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -35,7 +35,7 @@ url_parse = require('url').parse,
        fs = require('fs');
 var tunnelAgent = null;
 var debug;
-var api, email, token, period, sourceName;
+var api, email, token, period, sourceName, sourceRegex;
 
 // How long to wait before retrying a failed post, in seconds
 var retryDelaySecs = 5;
@@ -188,7 +188,7 @@ var timer_gauge_pct = function(timer_name, values, pct, suffix)
   }
 
   return {
-    name: sanitize_name(name),
+    name: name,
     count: numInThreshold,
     sum: sum,
     sum_squares: sumOfSquares,
@@ -212,6 +212,16 @@ var flush_stats = function librato_flush(ts, metrics)
 
   var addMeasure = function add_measure(mType, measure, countStat) {
     countStat = typeof countStat !== 'undefined' ? countStat : true;
+
+    var match;
+    if (sourceRegex && (match = measure.name.match(sourceRegex)) && match[1]) {
+      // Use first capturing group as source name
+      measure.source = sanitize_name(match[1]);
+      // Remove entire matching string from the measure name
+      measure.name = sanitize_name(measure.name.slice(0, match.index) + measure.name.slice(match.index + match[0].length));
+    } else {
+      measure.name = sanitize_name(measure.name);
+    }
 
     if (mType == 'counter') {
       counters.push(measure);
@@ -237,7 +247,7 @@ var flush_stats = function librato_flush(ts, metrics)
     }
 
     if (countersAsGauges) {
-      addMeasure('gauge', { name: sanitize_name(key),
+      addMeasure('gauge', { name: key,
                             value: metrics.counters[key]});
       continue;
     }
@@ -250,7 +260,7 @@ var flush_stats = function librato_flush(ts, metrics)
       libratoCounters[key].lastUpdate = ts;
     }
 
-    addMeasure('counter', { name: sanitize_name(key),
+    addMeasure('counter', { name: key,
                             value: libratoCounters[key].value});
   }
 
@@ -291,7 +301,7 @@ var flush_stats = function librato_flush(ts, metrics)
       continue;
     }
 
-    addMeasure('gauge', { name: sanitize_name(key),
+    addMeasure('gauge', { name: key,
                           value: metrics.gauges[key]});
   }
 
@@ -374,6 +384,7 @@ exports.init = function librato_init(startup_time, config, events)
     email = config.librato.email;
     token = config.librato.token;
     sourceName = config.librato.source;
+    sourceRegex = config.librato.sourceRegex;
     countersAsGauges = config.librato.countersAsGauges;
     snapTime = config.librato.snapTime;
     skipInternalMetrics = config.librato.skipInternalMetrics;


### PR DESCRIPTION
This is similar to https://github.com/librato/statsd-librato-backend/pull/8#commits-pushed-82e5e42 but uses a regex to allow for arbitrary source/measurement name formats.

Ideally statsd would let us do name validation in the backend, but this is still useful until then, just with a limited set of characters.

For issue #2 
