### PR TITLE
Use uri_parsed['hostname'] for Tunnel config instead of uri_parsed['host...

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -401,7 +401,7 @@ exports.init = function librato_init(startup_time, config, events)
 
       tunnelAgent = tunnelFunc({
         "proxy" : {
-          "host" : uri_parsed['host'],
+          "host" : uri_parsed['hostname'],
           "port" : uri_parsed['port'] || defaultPort
         }
       });


### PR DESCRIPTION
...']

http://nodejs.org/docs/latest/api/url.html host includes the port as well. So if my url in the proxy config is http://localhost:3128 then the tunnel config was 
"proxy" : {
          "host" : 'localhost:3128'
          "port" : '3128'
        }
