### PR TITLE
Default skip internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ StatsD config file.
 }
 ```
 
+The *email* and *token* settings can be found on your Librato account
+settings page. The *source* is an optional-but-recommended string to
+use as a
+[source](http://support.metrics.librato.com/knowledgebase/articles/47904-what-is-a-source-)
+for all measurements from this statsd instance. This should be unique
+for each statsd process.
+
 ## Enabling
 
 Add the `statsd-librato-backend` backend to the list of StatsD
@@ -49,10 +56,6 @@ pushed to your Librato Metrics account.
 
 The Librato backend also supports the following optional configuration
 options under the top-level `librato` hash:
-
-* `source`: An optional-but-recommended source name to use for all
-            measurements. This should be unique for each statsd
-            process.
 
 * `sourceRegex`: An optional JavaScript regular expression to extract
                  the source name from the measurement name. The first

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -6,25 +6,9 @@
  *
  *   backends: ['statsd-librato-backend']
  *
- * The backend will read the configuration options from the following
- * 'librato' hash defined in the main statsd config file:
- *
- *  librato : {
- *    email : Email address of your Librato Metrics account (req'd)
- *    token : API Token of your Librato Metrics accounts    (req'd)
- *    source: Name of a source to use for metrics (optional)
- *    snapTime : Lock timestamps to this interval in seconds (optional)
- *    countersAsGauges: Boolean on whether or not all counters should be
- *                      reported as gauges, as was originally done with
- *                      Librato's statsd. Defaults to false which means
- *                      counters will be published as native Metrics
- *                      counters.
- *    skipInternalMetrics: Boolean of whether to skip publishing of
- *                         internal statsd metrics. This includes all
- *                         metrics beginning with 'statsd.' and the
- *                         metric numStats. Default false -- they
- *                         are published to Librato.
- *  }
+ * The backend will read the configuration options from the main
+ * statsd configuration file under the sub-hash key 'librato'. See the
+ * README in this repository for available configuration options.
  */
 
 var   net = require('net'),


### PR DESCRIPTION
In most cases these are not useful and simply add more noise. Worst case, they can create metric type conflicts when two statsd's have different _countersAsGauges_ settings.
