### PR TITLE
Handle the sourceRegex set as a string instead of a regular exp.

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -379,6 +379,17 @@ exports.init = function librato_init(startup_time, config, events)
     sourceRegex = config.librato.sourceRegex;
     snapTime = config.librato.snapTime;
 
+    // Handle the sourceRegex as a string
+    if (typeof sourceRegex == 'string') {
+      // XXX: Converting to Regexp will add another enclosing '//'
+      if (sourceRegex.length > 2 && sourceRegex[0] == '/' &&
+          sourceRegex[sourceRegex.length - 1] == '/') {
+        sourceRegex = new RegExp(sourceRegex.slice(1, sourceRegex.length - 1));
+      } else {
+        sourceRegex = new RegExp(sourceRegex);
+      }
+    }
+
     if (config.librato.countersAsGauges != null) {
       countersAsGauges = config.librato.countersAsGauges;
     }


### PR DESCRIPTION
It's possible that certain CM environments won't preserve the regex
setting and set all config fields as string values. Be smart and fall
back to converting from string to RegExp. It gets a bit messy because
RegExp() will automatically add the //'s to enclose the string, so we
strip them off if we see them set at the beginning and end of the
string.
