### PR TITLE
Added histogram support

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -285,9 +285,9 @@ var flush_stats = function librato_flush(ts, metrics)
         var bin;
         for (bin in histogram) {
           var name = key + '.' + bin;
-
+          // Bins are not counted in numStats
           addMeasure('gauge', { name: name,
-                            value: histogram[bin]});
+                                value: histogram[bin]}, false);
         }
       }
     }


### PR DESCRIPTION
Each bin is sent to Librato as a gauge. This should resolve issue #25.
