### PR TITLE
Leverage the new backend logger to log all messages if set.

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -20,7 +20,7 @@ url_parse = require('url').parse,
      http = require('http'),
        fs = require('fs');
 var tunnelAgent = null;
-var debug;
+var debug, logAll;
 var api, email, token, period, sourceName, sourceRegex;
 
 // How long to wait before retrying a failed post, in seconds
@@ -59,30 +59,30 @@ var post_payload = function(options, proto, payload, retry)
       if (Math.floor(res.statusCode / 100) == 5){
         var errdata = "HTTP " + res.statusCode + ": " + d;
         if (retry){
-          if (debug) {
-            util.log("Error sending metrics to Librato: " + errdata);
+          if (logAll) {
+            util.log("Failed to post to Librato: " + errdata, "LOG_ERR");
           }
           setTimeout(function() {
             post_payload(options, proto, payload, false);
           }, retryDelaySecs * 1000);
         } else {
-          util.log("Error connecting to Librato!\n" + errdata,"crit");
+          util.log("Failed to connect to Librato: " + errdata, "LOG_ERR");
         }
       }
 
       // Log 4xx errors
       if (Math.floor(res.statusCode / 100) == 4){
         var errdata = "HTTP " + res.statusCode + ": " + d;
-        if (debug) {
-          util.log("Error sending metrics to Librato: " + errdata);
+        if (logAll) {
+          util.log("Failed to post to Librato: " + errdata, "LOG_ERR");
         }
       }
     });
   });
 
   req.setTimeout(postTimeoutSecs * 1000, function(request) {
-    if (debug) {
-      util.log("Timed out sending metrics to Librato");
+    if (logAll) {
+      util.log("Timed out sending metrics to Librato", "LOG_ERR");
     }
     req.end();
   });
@@ -97,7 +97,7 @@ var post_payload = function(options, proto, payload, retry)
         post_payload(options, proto, payload, false);
       }, retryDelaySecs * 1000);
     } else {
-      util.log("Error connecting to Librato!\n" + errdata);
+      util.log("Failed to connect to Librato: " + errdata, "LOG_ERR");
     }
   });
 };
@@ -360,7 +360,7 @@ var build_user_agent = function()
     json = JSON.parse(str);
     version = json['version'];
   } catch (e) {
-    if (debug) {
+    if (logAll) {
       util.log(e);
     }
   }
@@ -370,10 +370,11 @@ var build_user_agent = function()
 
 exports.init = function librato_init(startup_time, config, events, logger)
 {
-  debug = config.debug;
+  logAll = debug = config.debug;
 
   if (typeof logger !== 'undefined') {
     util = logger; // override the default
+    logAll = true;
   }
 
   // Config options are nested under the top-level 'librato' hash
@@ -415,8 +416,8 @@ exports.init = function librato_init(startup_time, config, events, logger)
       try {
         tunnel = require('tunnel');
       } catch (e) {
-        util.log("Error cannot find module 'tunnel'.");
-        util.log("Make sure to run `npm install tunnel`.");
+        util.log("Cannot find module 'tunnel'.", "LOG_CRIT");
+        util.log("Make sure to run `npm install tunnel`.", "LOG_CRIT");
         return false;
       }
 
@@ -453,7 +454,7 @@ exports.init = function librato_init(startup_time, config, events, logger)
   }
 
   if (!email || !token) {
-    util.log("Error: Invalid configuration for Librato Metrics backend");
+    util.log("Invalid configuration for Librato Metrics backend", "LOG_CRIT");
     return false;
   }
 


### PR DESCRIPTION
This way the log level can be controlled from the top-level and not
require setting 'debug:true' to get error messages.

/cc @till
