### PR TITLE
Prevent payloads rejection due to single broken metric

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.8"
+before_script:
+  - npm install -g nodeunit

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -51,6 +51,11 @@ var skipInternalMetrics = true;
 // counters.
 var libratoCounters = {};
 
+// Librato web service can't ignore individual broken metrics
+// instead it's dropping whole payloads
+// So we place such metrics to stoplist
+var brokenMetrics = {};
+
 var post_payload = function(options, proto, payload, retry)
 {
   var req = proto.request(options, function(res) {
@@ -75,6 +80,26 @@ var post_payload = function(options, proto, payload, retry)
         var errdata = "HTTP " + res.statusCode + ": " + d;
         if (logAll) {
           util.log("Failed to post to Librato: " + errdata, "LOG_ERR");
+        }
+        if (/^application\/json/.test(res.headers['content-type'])) {
+          var meta = JSON.parse(d),
+              fields = meta.errors.params.type,
+              re = /'([^']+)' is a \S+, but was submitted as different type/;
+          if (fields && fields.length) {
+            for (var i=0; i < fields.length; i++) {
+              var match  = re.exec(fields[i]),
+                  field = match && match[1];
+              if (field && !brokenMetrics[field]) {
+                brokenMetrics[field] = true;
+                if (logAll) {
+                  util.log(
+                    "Placing metric '" + field + "' to stoplist until service restart",
+                    "LOG_ERR"
+                  );
+                }
+              }
+            }
+          }
         }
       }
     });
@@ -206,6 +231,10 @@ var flush_stats = function librato_flush(ts, metrics)
       measure.name = sanitize_name(measure.name.slice(0, match.index) + measure.name.slice(match.index + match[0].length));
     } else {
       measure.name = sanitize_name(measure.name);
+    }
+
+    if (brokenMetrics[measure.name]) {
+      return;
     }
 
     if (mType == 'counter') {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   },
   "dependencies": {},
   "devDependencies": {},
-  "main": "lib/librato.js"
+  "main": "lib/librato.js",
+  "scripts": {
+    "test": "nodeunit test"
+  }
 }

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -1,0 +1,89 @@
+var librato_init = require('../lib/librato.js').init,
+    http = require('http'),
+    events = require('events'),
+    server_port = 36001;
+
+module.exports = {
+  setUp: function(callback) {
+    this.server = http.createServer();
+    this.server.listen(server_port, '127.0.0.1', function() {
+      callback();
+    });
+  },
+
+  tearDown: function (callback) {
+    this.server.close(function() {
+      callback();
+    });
+  },
+
+  testIgnoreBrokenMetrics: function(test) {
+    var emitter = new events.EventEmitter(),
+        server = this.server;
+    var metrics = {
+          gauges: {
+            cool_gauge: 123,
+            bad_counter: 321
+          }
+        };
+    var api_mock = function (reject_metric) {
+      return function(req, res) {
+        var data = '';
+        req.on('data', function(chunk) {
+          data += chunk;
+        });
+        req.on('end', function() {
+          var body = JSON.parse(data),
+              gauges = {};
+          for (var k in body.gauges) {
+            gauges[body.gauges[k].name] = body.gauges[k].value;
+          }
+          if (reject_metric) {
+            test.ok(gauges.bad_counter);
+            test.ok(gauges.cool_gauge);
+
+            res.writeHead(
+              400,
+              {'content-type': 'application/json'}
+            );
+            res.end(JSON.stringify({
+              errors: {
+                params: {
+                  type: [
+                    "'bad_counter'" +
+                      " is a counter, but was" +
+                      " submitted as different type"
+                  ]
+                }
+              }
+            }));
+            setTimeout(function() {
+              server.once('request', api_mock(false));
+              emitter.emit('flush', 123, metrics);
+            }, 100);
+          } else {
+            res.writeHead(200, {});
+            res.end('');
+
+            test.strictEqual(gauges.bad_counter, undefined);
+            test.ok(gauges.cool_gauge);
+
+            test.done();
+          }
+        });
+      };
+    }
+
+    librato_init(null, {
+      debug: false,
+      librato: {
+        email: '-@-',
+        token: '-',
+        api: 'http://127.0.0.1:' + server_port
+      }
+    }, emitter);
+
+    server.once('request', api_mock(true));
+    emitter.emit('flush', 123, metrics);
+  }
+};


### PR DESCRIPTION
If metric for some reason changes it's type (e.g. counter => gauge)
Librato API begins to reject whole payloads containing this metric.

That's terrible, since one metric can stop the whole statsd instace from functioning.

Suggested workaround adds such rejected metrics to the stop list, removing them from all future metric payloads until statsd instance restart.
