### PR TITLE
Fix native counters when using deleteIdleStats

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -333,10 +333,6 @@ var flush_stats = function librato_flush(ts, metrics)
     }
   }
 
-  if (gauges.length > 0 || counters.length > 0) {
-    post_metrics(measureTime, gauges, counters);
-  }
-
   // Delete any counters that were not published, as they
   // were deleted.
   var toDelete = [];
@@ -345,7 +341,14 @@ var flush_stats = function librato_flush(ts, metrics)
       continue;
     }
 
+    // Push a zero to ensure the next delta is correct
+    addMeasure('counter', { name: key, value: 0 });
+
     toDelete.push(key);
+  }
+
+  if (gauges.length > 0 || counters.length > 0) {
+    post_metrics(measureTime, gauges, counters);
   }
 
   for (var i = 0; i < toDelete.length; i++) {


### PR DESCRIPTION
When using native Librato counters (countersAsGauges:false) and periodically incrementing a statsd counter by one, you'll see the following on your graph:

(time: t_1, value: 10, delta: 1)
(time: t_4, value: 11, delta: 1)
...

However, if you enable deleteIdleStats and don't push an increment during a flush interval, the counter state is deleted in the backend and you'll see the following as the value is restarted at one for each increment:

(time: t_1, value: 1, delta: 0)
(time: t_4, value: 1, delta: 0)

This patch will push a zero when the counter is deleted (ie, wasn't updated in a flush interval), thereby giving the following:

(time: t_0, value 0, delta: 0)
(time: t_1, value 1, delta: 1)
(time: t_2, value 0, delta: 0)
(time: t_4, value 1, delta: 1)

Which should match the deltas when not deleting the counters in between increments.
