### PR TITLE
Never delete counter state tracking.

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -333,26 +333,8 @@ var flush_stats = function librato_flush(ts, metrics)
     }
   }
 
-  // Delete any counters that were not published, as they
-  // were deleted.
-  var toDelete = [];
-  for (key in libratoCounters) {
-    if (libratoCounters[key].lastUpdate == ts) {
-      continue;
-    }
-
-    // Push a zero to ensure the next delta is correct
-    addMeasure('counter', { name: key, value: 0 });
-
-    toDelete.push(key);
-  }
-
   if (gauges.length > 0 || counters.length > 0) {
     post_metrics(measureTime, gauges, counters);
-  }
-
-  for (var i = 0; i < toDelete.length; i++) {
-    delete libratoCounters[toDelete[i]];
   }
 };
 


### PR DESCRIPTION
Never delete counters so that the absolute tracking value is never lost. This allows counters to work nicely with deleteIdleStats.
