### PR TITLE
now you can explicitly name your 100% percentile via config

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -51,11 +51,9 @@ var skipInternalMetrics = true;
 // counters.
 var libratoCounters = {};
 
-// Do we want our 100% percentile in librato to be named as
-// metric_name or metric_name.[defaultPercentileName].
-// e.g. metric_name.100 if we set this to '100'
-//      metric_name if we set this to null
-var defaultPercentileName = null;
+// Do we always suffix 100 percentile with .100
+// e.g. metric_name.100
+var alwaysSuffixPercentile = false;
 
 var post_payload = function(options, proto, payload, retry)
 {
@@ -274,7 +272,7 @@ var flush_stats = function librato_flush(ts, metrics)
       key,
       sortedVals,
       100,
-      defaultPercentileName == null ? null : '.' + defaultPercentileName
+      alwaysSuffixPercentile ? '.100' : null
     );
 
     if (gauge) {
@@ -464,8 +462,8 @@ exports.init = function librato_init(startup_time, config, events, logger)
       maxBatchSize = config.librato.batchSize;
     }
 
-    if(config.librato.defaultPercentileName) {
-      defaultPercentileName = config.librato.defaultPercentileName;
+    if(config.librato.alwaysSuffixPercentile) {
+      alwaysSuffixPercentile = config.librato.alwaysSuffixPercentile;
     }
   }
 


### PR DESCRIPTION
**motivation:**

Let's say that I have named all my timers as `prefix.metric_name` and have `percentThreshold:[95,99]` set up in config.

This backend will name metrics in librato as `prefix.metric_name`, `prefix.metric_name.95` and `prefix.metric_name.99`. 

Now let's say that I want to create a composite mean metric in librato of all 100% percentile metrics that match `prefix.*` like so `mean(s("prefix.*", "*"))`. This will include all `prefix.*.9*` metrics.

---

Given this patch I'm able to explicitly name the 100% percentile metric. 

Example:

With `defaultPercentileName: '100'` and  `percentThreshold:[95,99]` in config.js I'll now have the following metrics available in librato: `prefix.metric_name.100`, `prefix.metric_name.95` and `prefix.metric_name.99`. 
