### PR TITLE
extract metric source and name from raw statsd metric name with functions in config

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -55,6 +55,10 @@ var libratoCounters = {};
 // e.g. metric_name.100
 var alwaysSuffixPercentile = false;
 
+// Functions used to extract source and name from raw metric name
+var measureName;
+var measureSource;
+
 var post_payload = function(options, proto, payload, retry)
 {
   var req = proto.request(options, function(res) {
@@ -204,7 +208,11 @@ var flush_stats = function librato_flush(ts, metrics)
     countStat = typeof countStat !== 'undefined' ? countStat : true;
 
     var match;
-    if (sourceRegex && (match = measure.name.match(sourceRegex)) && match[1]) {
+    if (measureName && measureSource) {
+      measure.source = sanitize_name(measureSource(measure.name))
+      measure.name = sanitize_name(measureName(measure.name))
+
+    } else if (sourceRegex && (match = measure.name.match(sourceRegex)) && match[1]) {
       // Use first capturing group as source name
       measure.source = sanitize_name(match[1]);
       // Remove entire matching string from the measure name
@@ -467,6 +475,14 @@ exports.init = function librato_init(startup_time, config, events, logger)
 
     if(config.librato.alwaysSuffixPercentile) {
       alwaysSuffixPercentile = config.librato.alwaysSuffixPercentile;
+    }
+
+    if(config.librato.measureSource) {
+      measureSource = config.librato.measureSource;
+    }
+
+    if(config.librato.measureName) {
+      measureName = config.librato.measureName;
     }
   }
 


### PR DESCRIPTION
**motivation**
- say we have a metric `project_name.source.metric_name`
- `sourceRegex` assumes that we want to omit `project_name` from metric name when pushed to librato
- this is bad since librato has a single global namespace for all metrics

**solution**

introduce `measureName` and `measureSource` function that can be put in config

usage:

```
 librato: {
    email:  "me@example.com",
    token:  "bla bla",
    measureName: function (name) {
      return name.replace(/^([^\.]+)\.([^\.]+)\./, '$1.');
    },
    measureSource: function (name) {
      return name.match(/^[^\.]+\.([^\.]+)\./)[1];
    }
  }

```
