### PR TITLE
functionality to filter and exclude metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,23 +102,28 @@ options under the top-level `librato` hash:
 * `postTimeoutSecs`: Max time for POST requests to Librato, in
                      seconds.
 
-* `filters`: An array of JavaScript regular expressions allows
-             only matching metrics to be sent to Librato. Defaults to
-			 an empty array.
+* `includeMetrics`: An array of JavaScript regular expressions. Only metrics
+					that match any of the regular expressions will be sent to Librato.
+					Defaults to an empty array.
 
 ```js
 {
-   filters: [/^my\.included\.metrics/, /^my.specifically.included.metric$/]
+   includeMetrics: [/^my\.included\.metrics/, /^my.specifically.included.metric$/]
 }
 ```
 
-* `excludes`: An array of JavaScript regular expressions that excludes
-              matching metrics from being sent to Librato. Defaults to
-			  an empty array.
+* `excludeMetrics`: An array of JavaScript regular expressions. Metrics which match
+					any of the regular expressions will NOT be sent to Librato. If includedMetrics
+					is specified, then patterns will be matched against the resulting
+					list of included metrics.
+					Defaults to an empty array.
+			  
+			  Metrics which are sent to StatsDThis will exclude metrics sent to StatsD so that metrics which
+			  match the specified regex value 
 
 ```js
 {
-   excludes: [/^my\.excluded\.metrics/, /^my.specifically.excluded.metric$/]
+   excludeMetrics: [/^my\.excluded\.metrics/, /^my.specifically.excluded.metric$/]
 }
 ```
 

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -21,7 +21,7 @@ url_parse = require('url').parse,
        fs = require('fs');
 var tunnelAgent = null;
 var debug, logAll;
-var api, email, token, period, sourceName, sourceRegex, filters, excludes;
+var api, email, token, period, sourceName, sourceRegex, includeMetrics, excludeMetrics;
 
 // How long to wait before retrying a failed post, in seconds
 var retryDelaySecs = 5;
@@ -202,22 +202,22 @@ var flush_stats = function librato_flush(ts, metrics)
 
   var excludeMetric = function (metric) {
       var matchesFilter = false;
-      for (var index = 0; index < filters.length; index++) {
-          if (filters[index].test(metric)) {
+      for (var index = 0; index < includeMetrics.length; index++) {
+          if (includeMetrics[index].test(metric)) {
               matchesFilter = true;
               break;
           }
       }
 
       var matchesExclude = false;
-      for (var index = 0; index < excludes.length; index++) {
-          if (excludes[index].test(metric)) {
+      for (var index = 0; index < excludeMetrics.length; index++) {
+          if (excludeMetrics[index].test(metric)) {
               matchesExclude = true;
               break;
           }
       }
 
-      return ((filters.length > 0) && !matchesFilter) || matchesExclude;
+      return ((includeMetrics.length > 0) && !matchesFilter) || matchesExclude;
   }
 
   var addMeasure = function add_measure(mType, measure, countStat) {
@@ -435,31 +435,31 @@ exports.init = function librato_init(startup_time, config, events, logger)
     sourceName = config.librato.source;
     sourceRegex = config.librato.sourceRegex;
     snapTime = config.librato.snapTime;
-    filters = config.librato.filters;
-    excludes = config.librato.excludes;
+    includeMetrics = config.librato.includeMetrics;
+    excludeMetrics = config.librato.excludeMetrics;
 
     // Handle the sourceRegex as a string
     if (typeof sourceRegex == 'string') {
       sourceRegex = convert_string_to_regex(sourceRegex);
     }
 
-    if (!Array.isArray(filters)) {
-      filters = [];
+    if (!Array.isArray(includeMetrics)) {
+      includeMetrics = [];
     }
 
-    for (var index = 0; index < filters.length; index++) {
-      if (typeof filters[index] == 'string') {
-        filters[index] = convert_string_to_regex(filters[index]);
+    for (var index = 0; index < includeMetrics.length; index++) {
+      if (typeof includeMetrics[index] == 'string') {
+        includeMetrics[index] = convert_string_to_regex(includeMetrics[index]);
       }
     }
 
-    if (!Array.isArray(excludes)) {
-      excludes = [];
+    if (!Array.isArray(excludeMetrics)) {
+      excludeMetrics = [];
     }
 
-    for (var index = 0; index < excludes.length; index++) {
-      if (typeof excludes[index] == 'string') {
-        excludes[index] = convert_string_to_regex(excludes[index]);
+    for (var index = 0; index < excludeMetrics.length; index++) {
+      if (typeof excludeMetrics[index] == 'string') {
+        excludeMetrics[index] = convert_string_to_regex(excludeMetrics[index]);
       }
     }
 


### PR DESCRIPTION
The statsd instance I am using is handling more stats than needed to be sent to librato because they were being monitored through graphite.  In order to only send the stats I want in Librato I added functionality which allows for a combination of metrics to be filtered out and/or to be specifically excluded from being sent.  This helps give greater control over of what is sent so charges aren't incurred for metrics that aren't being used through the Librato interface.
