### PR TITLE
Added globalPrefix configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ options under the top-level `librato` hash:
 }
 ```
 
+* `globalPrefix`: A string to prepend to all measurement names sent to Librato. If set, a dot
+                  will automatically be added as separator between prefix and measurement name.
+
 ## Reducing published data for inactive stats
 
 By default StatsD will push a zero value for any counter that does not

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -55,6 +55,9 @@ var libratoCounters = {};
 // e.g. metric_name.100
 var alwaysSuffixPercentile = false;
 
+// A string to prepend to all measurement names sent to Librato.
+var globalPrefix = "";
+
 var post_payload = function(options, proto, payload, retry)
 {
   var req = proto.request(options, function(res) {
@@ -227,10 +230,10 @@ var flush_stats = function librato_flush(ts, metrics)
     if (sourceRegex && (match = measure.name.match(sourceRegex)) && match[1]) {
       // Use first capturing group as source name
       measure.source = sanitize_name(match[1]);
-      // Remove entire matching string from the measure name
-      measure.name = sanitize_name(measure.name.slice(0, match.index) + measure.name.slice(match.index + match[0].length));
+      // Remove entire matching string from the measure name & add global prefix.
+      measure.name = globalPrefix + sanitize_name(measure.name.slice(0, match.index) + measure.name.slice(match.index + match[0].length));
     } else {
-      measure.name = sanitize_name(measure.name);
+      measure.name = globalPrefix + sanitize_name(measure.name);
     }
 
     if (mType == 'counter') {
@@ -523,6 +526,10 @@ exports.init = function librato_init(startup_time, config, events, logger)
 
     if(config.librato.alwaysSuffixPercentile) {
       alwaysSuffixPercentile = config.librato.alwaysSuffixPercentile;
+    }
+
+    if(config.librato.globalPrefix) {
+      globalPrefix = config.librato.globalPrefix + '.';
     }
   }
 


### PR DESCRIPTION
## Justification
 
Add a global prefix to namespace metrics sent to Librato which are coming from different services.
 
 
## Usage
 
```js
{ librato: {
    email: "me@example.com",
    token: "abcdefghijklmnopqrstuvwxyz1234567890",
    globalPrefix: "stats"
  }
}
```
 
If set, a dot will automatically be added as separator between prefix and measurement name.