### PR TITLE
Show full config file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ StatsD config file.
 }
 ```
 
-Example Full Config
+Example Full Configuration File:
 
 ```js
 {
@@ -39,11 +39,10 @@ Example Full Config
     email:  "myemail@example.com",
     token:  "ca98e2bc23b1bfd0cbe9041e824f610491129bb952d52ca4ac22cf3eab5a1c32",
     source: "unique-per-statsd-instance"
-}
+  }
   , backends: ["statsd-librato-backend"]
   , port: 8125
-  , debug: true
-  , dumpMessages: true
+  
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ StatsD config file.
     email:  "myemail@example.com",
     token:  "ca98e2bc23b1bfd0cbe9041e824f610491129bb952d52ca4ac22cf3eab5a1c32",
     source: "unique-per-statsd-instance"
-   }
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,25 @@ StatsD config file.
     email:  "myemail@example.com",
     token:  "ca98e2bc23b1bfd0cbe9041e824f610491129bb952d52ca4ac22cf3eab5a1c32",
     source: "unique-per-statsd-instance"
-  }
 }
 ```
+
+Example Full Config
+
+```js
+{
+  librato: {
+    email:  "myemail@example.com",
+    token:  "ca98e2bc23b1bfd0cbe9041e824f610491129bb952d52ca4ac22cf3eab5a1c32",
+    source: "unique-per-statsd-instance"
+}
+  , backends: ["statsd-librato-backend"]
+  , port: 8125
+  , debug: true
+  , dumpMessages: true
+}
+```
+
 
 The *email* and *token* settings can be found on your Librato account
 settings page. The *source* is an optional-but-recommended string to

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ StatsD config file.
     email:  "myemail@example.com",
     token:  "ca98e2bc23b1bfd0cbe9041e824f610491129bb952d52ca4ac22cf3eab5a1c32",
     source: "unique-per-statsd-instance"
+   }
 }
 ```
 


### PR DESCRIPTION
Avoid confusion that might be caused by showing a partial config file by showing a full config file.