### PR TITLE
Use https-proxy-agent instead of tunnel. Fixes #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ options under the top-level `librato` hash:
                      seconds.
 
 * `includeMetrics`: An array of JavaScript regular expressions. Only metrics
-					that match any of the regular expressions will be sent to Librato.
-					Defaults to an empty array.
+                    that match any of the regular expressions will be sent to Librato.
+                    Defaults to an empty array.
 
 ```js
 {
@@ -128,13 +128,13 @@ options under the top-level `librato` hash:
 ```
 
 * `excludeMetrics`: An array of JavaScript regular expressions. Metrics which match
-					any of the regular expressions will NOT be sent to Librato. If includedMetrics
-					is specified, then patterns will be matched against the resulting
-					list of included metrics.
-					Defaults to an empty array.
-			  
-			  Metrics which are sent to StatsDThis will exclude metrics sent to StatsD so that metrics which
-			  match the specified regex value 
+                    any of the regular expressions will NOT be sent to Librato. If includedMetrics
+                    is specified, then patterns will be matched against the resulting
+                    list of included metrics.
+                    Defaults to an empty array.
+
+              Metrics which are sent to StatsDThis will exclude metrics sent to StatsD so that metrics which
+              match the specified regex value
 
 ```js
 {
@@ -219,9 +219,9 @@ See the [statsd][statsd] manpage for more information.
 ## Using Proxy
 
 If you want to use statsd-librato-backend througth a proxy you should
-install **tunnel** module:
+install **https-proxy-agent** module:
 
-        $npm install tunnel
+        $npm install https-proxy-agent
 
 After that you should add the *proxy* config to the StatsD config file
 in the librato configuration section:

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -61,7 +61,7 @@ var globalPrefix = "";
 
 var post_payload = function(options, proto, payload, retry)
 {
- var req = proto.request(options, function(res) {
+  var req = proto.request(options, function(res) {
     res.on('data', function(d) {
       // Retry 5xx codes
       if (Math.floor(res.statusCode / 100) == 5){

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -20,6 +20,7 @@ url_parse = require('url').parse,
      http = require('http'),
        fs = require('fs');
 var tunnelAgent = null;
+
 var debug, logAll;
 var api, email, token, period, sourceName, sourceRegex, includeMetrics, excludeMetrics;
 
@@ -60,7 +61,7 @@ var globalPrefix = "";
 
 var post_payload = function(options, proto, payload, retry)
 {
-  var req = proto.request(options, function(res) {
+ var req = proto.request(options, function(res) {
     res.on('data', function(d) {
       // Retry 5xx codes
       if (Math.floor(res.statusCode / 100) == 5){
@@ -93,7 +94,6 @@ var post_payload = function(options, proto, payload, retry)
     }
     req.end();
   });
-
   req.write(payload);
   req.end();
 
@@ -116,6 +116,7 @@ var post_metrics = function(ts, gauges, counters)
                  measure_time: ts};
 
   var parsed_host = url_parse(api || 'https://metrics-api.librato.com');
+
 
   if (sourceName) {
     payload.source = sourceName;
@@ -481,35 +482,17 @@ exports.init = function librato_init(startup_time, config, events, logger)
     }
 
     if (config.librato.proxy && config.librato.proxy.uri) {
-      var tunnel;
+
+      var tunnelFunc;
       try {
-        tunnel = require('tunnel');
-      } catch (e) {
-        util.log("Cannot find module 'tunnel'.", "LOG_CRIT");
-        util.log("Make sure to run `npm install tunnel`.", "LOG_CRIT");
-        return false;
+          tunnelFunc = require('https-proxy-agent');
+      } catch(e) {
+           util.log("Cannot find module 'https-proxy-agent'.", "LOG_CRIT");
+           util.log("Make sure to run `npm install https-proxy-agent`.", "LOG_CRIT");
+           return false;
       }
 
-      var uri_parsed = url_parse(config.librato.proxy.uri);
-      var defaultPort, tunnelFunc;
-
-      if (uri_parsed['protocol'] == 'https') {
-        tunnelFunc = tunnel.httpsOverHttps;
-        defaultPort = 443;
-      } else {
-        tunnelFunc = tunnel.httpsOverHttp;
-        defaultPort = 80;
-      }
-
-      var proxySettings = {
-        "proxy" : {
-          "host" : uri_parsed['hostname'],
-          "port" : uri_parsed['port'] || defaultPort,
-          "proxyAuth": uri_parsed['auth'] || null
-        }
-      };
-
-      tunnelAgent = tunnelFunc(proxySettings);
+      tunnelAgent = new tunnelFunc( config.librato.proxy.uri );
     }
 
     if (config.librato.retryDelaySecs) {


### PR DESCRIPTION
Used the module **https-proxy-agent** instead of tunnel seeing that with node 0.12.7 is not working. 

Tested on our environment and it is working. Keeping on mind that I am not a node expert :D 