### PR TITLE
Add globalPrefix before performing sourceRegex match

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -253,13 +253,15 @@ var flush_stats = function librato_flush(ts, metrics)
     countStat = typeof countStat !== 'undefined' ? countStat : true;
 
     var match;
-    if (sourceRegex && (match = measure.name.match(sourceRegex)) && match[1]) {
-      // Use first capturing group as source name
+    var measureName = globalPrefix + measure.name;
+
+    // Use first capturing group as source name
+    if (sourceRegex && (match = measureName.match(sourceRegex)) && match[1]) {
       measure.source = sanitize_name(match[1]);
       // Remove entire matching string from the measure name & add global prefix.
-      measure.name = globalPrefix + sanitize_name(measure.name.slice(0, match.index) + measure.name.slice(match.index + match[0].length));
+      measure.name = sanitize_name(measureName.slice(0, match.index) + measureName.slice(match.index + match[0].length));
     } else {
-      measure.name = globalPrefix + sanitize_name(measure.name);
+      measure.name = sanitize_name(measureName);
     }
 
     if (brokenMetrics[measure.name]) {


### PR DESCRIPTION
This would allow me to decide if I want the global prefix in my source or my metric name. Before the only option is to prefix the metric name.

Side note: might be nice to trim leading and trailing periods from both.