### PR TITLE
Better checking for response content.

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -91,9 +91,9 @@ var post_payload = function(options, proto, payload, retry)
         }
         if (/^application\/json/.test(res.headers['content-type'])) {
           var meta = JSON.parse(d),
-              fields = meta.errors.params.type,
               re = /'([^']+)' is a \S+, but was submitted as different type/;
-          if (fields && fields.length) {
+          if (meta.errors && meta.errors.params && meta.errors.params.type.length) {
+            var fields = meta.errors.params.type;
             for (var i=0; i < fields.length; i++) {
               var match  = re.exec(fields[i]),
                   field = match && match[1];


### PR DESCRIPTION
Currently, it is assumed that the only reason a 4xx response could be returned is for 400 errors. However if a service is rate limited this result in a crash.

This should fix that.