### PR TITLE
Librato MD Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ config in the librato configuration section of the StatsD config file:
 Once your config has been updated, all metrics submitted to Librato will inclue your defined tags.
 If a source name exists, we will automatically submit the source as a tag as well. 
 
-By default, this functionality is disabled.
+By default, this functionality is disabled and is newly supported by Librato. If you are interested in using this feature, you can reach out to our support team and request access.
 
 ## NPM Dependencies
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,22 @@ protocol to https in the URI.
 
 ## Tags
 
-TODO
+Our backend plugin offers basic tagging support for your metrics you submit to Librato. You can specify what tags you want to submit to Librato using the *tags*
+config in the librato configuration section of the StatsD config file:
+
+
+```js
+{
+  "librato" : {
+    "tags": { "os" : "ubuntu", "hostname" : "production-web-server-1", ... }
+  }
+}
+```
+
+Once your config has been updated, all metrics submitted to Librato will inclue your defined tags.
+If a source name exists, we will automatically submit the source as a tag as well. 
+
+By default, this functionality is disabled.
 
 ## NPM Dependencies
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ config in the librato configuration section of the StatsD config file:
 Once your config has been updated, all metrics submitted to Librato will inclue your defined tags.
 If a source name exists, we will automatically submit the source as a tag as well. 
 
-By default, this functionality is disabled and is newly supported by Librato. If you are interested in using this feature, you can reach out to our support team and request access.
+By default, this functionality is disabled and is newly supported by Librato. If you are interested in using this feature, you send us an email at [support@librato.com](support@librato.com) and request access. 
 
 ## NPM Dependencies
 

--- a/README.md
+++ b/README.md
@@ -257,11 +257,11 @@ If a source name exists, we will automatically submit the source as a tag as wel
 We also support tags at the per-stat level should you need more detailed tagging. We provide a naming syntax for your stats so you can submit tags for each stat. That syntax is as follows:
 
 ```
-metric.name:value|#tag1:value,tag2:value
+metric.name:value#tag1=value,tag2=value
 ```
 
-Starting with a `|#`, you would pass in a comma-separated list of tags and we will parse out the tags and values. Given the above example, a stat matching
-the above syntax will be submitted as metric to Librato with a name of `metric.name`, a value of `value` and with the tags `tag1:value` and `tag2:value.
+Starting with a `#`, you would pass in a comma-separated list of tags and we will parse out the tags and values. Given the above example, a stat matching
+the above syntax will be submitted as metric to Librato with a name of `metric.name`, a value of `value` and with the tags `tag1=value` and `tag2=value. You are welcome to use any statsd client of your choosing.
 
 
 By default, this functionality is disabled and is newly supported by Librato. If you are interested in using this feature, you send us an email at [support@librato.com](support@librato.com) and request access. 

--- a/README.md
+++ b/README.md
@@ -251,10 +251,20 @@ config in the librato configuration section of the StatsD config file:
 }
 ```
 
-Once your config has been updated, all metrics submitted to Librato will inclue your defined tags.
+Once your config has been updated, all metrics submitted to Librato will include your defined tags.
 If a source name exists, we will automatically submit the source as a tag as well. 
 
-By default, this functionality is disabled and is newly supported by Librato. If you are interested in using this feature, you can send us an email at [support@librato.com](support@librato.com) and request access. 
+We also support tags at the per-stat level should you need more detailed tagging. We provide a naming syntax for your stats so you can submit tags for each stat. That syntax is as follows:
+
+```
+metric.name:value|#tag1:value,tag2:value
+```
+
+Starting with a `|#`, you would pass in a comma-separated list of tags and we will parse out the tags and values. Given the above example, a stat matching
+the above syntax will be submitted as metric to Librato with a name of `metric.name`, a value of `value` and with the tags `tag1:value` and `tag2:value.
+
+
+By default, this functionality is disabled and is newly supported by Librato. If you are interested in using this feature, you send us an email at [support@librato.com](support@librato.com) and request access. 
 
 ## NPM Dependencies
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ That configuration will proxy requests via a proxy listening on
 localhost on port 8080. You can also use an https proxy by setting the
 protocol to https in the URI.
 
+## Tags
+
+TODO
+
 ## NPM Dependencies
 
 None

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -154,7 +154,6 @@ var post_metrics = function(ts, gauges, counters)
   }
   
   if (multidimensional) {
-    payload.tags = tags;
     path = "/v1/measurements";
   }
 
@@ -277,6 +276,10 @@ var flush_stats = function librato_flush(ts, metrics)
 
     if (brokenMetrics[measure.name]) {
       return;
+    }
+    
+    if (multidimensional) {
+      measure.tags = tags;      
     }
 
     if (mType == 'counter') {

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -146,23 +146,16 @@ var post_metrics = function(ts, gauges, counters)
 
   var parsed_host = url_parse(api || 'https://metrics-api.librato.com');
   
-  var path = "/v1/metrics";
-
-
   if (sourceName) {
     payload.source = sourceName;
   }
   
-  if (multidimensional) {
-    path = "/v1/measurements";
-  }
-
   payload = JSON.stringify(payload);
 
   var options = {
     host: parsed_host["hostname"],
     port: parsed_host["port"] || 443,
-    path: path,
+    path: "/v1/metrics",
     method: 'POST',
     headers: {
       "Authorization": basicAuthHeader,
@@ -183,6 +176,44 @@ var post_metrics = function(ts, gauges, counters)
 
   post_payload(options, proto, payload, true);
 };
+
+var post_measurements = function(ts, measurements) 
+{
+  var payload = {
+    time: ts,
+    tags: tags,
+    measurements: measurements
+  };
+  
+  var parsed_host = url_parse(api || 'https://metrics-api.librato.com');
+  
+  payload = JSON.stringify(payload);
+
+  var options = {
+    host: parsed_host["hostname"],
+    port: parsed_host["port"] || 443,
+    path: "/v1/measurements",
+    method: 'POST',
+    headers: {
+      "Authorization": basicAuthHeader,
+      "Content-Length": payload.length,
+      "Content-Type": "application/json",
+      "User-Agent" : userAgent
+    }
+ };
+
+ if (tunnelAgent) {
+   options["agent"] = tunnelAgent;
+ }
+
+  var proto = http;
+  if ((parsed_host["protocol"] || 'http:').match(/https/)) {
+    proto = https;
+  }
+
+  post_payload(options, proto, payload, true);
+  
+}
 
 var sanitize_name = function(name)
 {
@@ -229,8 +260,14 @@ var flush_stats = function librato_flush(ts, metrics)
 {
   var numStats = 0, statCount;
   var key;
+  
+  // Librato SD Metrics
   var counters = [];
   var gauges = [];
+  
+  // Librato MD Metrics
+  var measurements = []; 
+  
   var measureTime = ts;
   var internalStatsdRe = /^statsd\./;
 
@@ -279,25 +316,31 @@ var flush_stats = function librato_flush(ts, metrics)
     }
     
     if (multidimensional) {
-      measure.tags = tags;      
-    }
-
-    if (mType == 'counter') {
-      counters.push(measure);
+      measurements.push(measure);
+      
+      // Post MD measurement
+      // TODO Batch support?
+      post_measurements(measureTime, measurements);
+      
     } else {
-      gauges.push(measure);
-    }
+      if (mType == 'counter') {
+        counters.push(measure);
+      } else {
+        gauges.push(measure);
+      }
 
-    if (countStat) {
-      numStats += 1;
-    }
+      if (countStat) {
+        numStats += 1;
+      }
 
-    // Post measurements and clear arrays if past batch size
-    if (counters.length + gauges.length >= maxBatchSize) {
-      post_metrics(measureTime, gauges, counters);
-      gauges = [];
-      counters = [];
+      // Post measurements and clear arrays if past batch size
+      if (counters.length + gauges.length >= maxBatchSize) {
+        post_metrics(measureTime, gauges, counters);
+        gauges = [];
+        counters = [];
+      }
     }
+    
   };
 
   for (key in metrics.counters) {

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -296,13 +296,6 @@ var flush_stats = function librato_flush(ts, metrics)
     
     if (multidimensional) {
       measurements.push(measure);
-      
-      // Post MD measurement
-      if (measurements.length >= maxBatchSize) {
-        post_measurements(measureTime, measurements);
-        measurements = [];
-      }
-      
     } else {
       if (mType == 'counter') {
         counters.push(measure);
@@ -314,14 +307,14 @@ var flush_stats = function librato_flush(ts, metrics)
         numStats += 1;
       }
 
-      // Post measurements and clear arrays if past batch size
-      if (counters.length + gauges.length >= maxBatchSize) {
-        post_metrics(measureTime, gauges, counters, measurements);
-        gauges = [];
-        counters = [];
-      }
     }
     
+    // Post measurements and clear arrays if past batch size
+    if ((counters.length + gauges.length >= maxBatchSize) || measurements >= maxBatchSize) {
+      post_metrics(measureTime, gauges, counters, measurements);
+      gauges = [];
+      counters = [];
+    }
   };
 
   for (key in metrics.counters) {

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -145,6 +145,8 @@ var post_metrics = function(ts, gauges, counters)
                  measure_time: ts};
 
   var parsed_host = url_parse(api || 'https://metrics-api.librato.com');
+  
+  var path = "/v1/metrics";
 
 
   if (sourceName) {
@@ -153,6 +155,7 @@ var post_metrics = function(ts, gauges, counters)
   
   if (multidimensional) {
     payload.tags = tags;
+    path = "/v1/measurements";
   }
 
   payload = JSON.stringify(payload);
@@ -160,7 +163,7 @@ var post_metrics = function(ts, gauges, counters)
   var options = {
     host: parsed_host["hostname"],
     port: parsed_host["port"] || 443,
-    path: '/v1/metrics',
+    path: path,
     method: 'POST',
     headers: {
       "Authorization": basicAuthHeader,

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -277,9 +277,14 @@ var flush_stats = function librato_flush(ts, metrics)
 
   var addMeasure = function add_measure(mType, measure, countStat) {
     countStat = typeof countStat !== 'undefined' ? countStat : true;
-
+    
     var match;
     var measureName = globalPrefix + measure.name;
+    
+    if (multidimensional) {
+      measure.tags = {}
+      measureName = parse_tags(measureName, measure.tags);
+    }
 
     // Use first capturing group as source name
     if (sourceRegex && (match = measureName.match(sourceRegex)) && match[1]) {
@@ -316,8 +321,33 @@ var flush_stats = function librato_flush(ts, metrics)
       counters = [];
     }
   };
-
+  
+  var parse_tags = function (measureName, measureTags) {
+    // Valid format for parsing tags out: global-prefix.name#tag1=value,tag2=value
+    // NOTE: Name can include the source
+    var vals = measureName.split("#")
+    if (vals.length > 1) {
+      // Found tags in the measureName. Parse them out and return the measureName without the tags.
+      measureName = vals.shift();
+      rawTags = vals.pop().split(",");
+      if (logAll) {
+        util.log('Found tags: ' + rawTags);
+      }
+      rawTags.forEach(function(rawTag) {
+        var name = rawTag.split("=").shift();
+        var value = rawTag.split("=").pop();
+        measureTags[name] = value;
+      });
+      
+      return measureName;
+    } else {
+      // No tags existed in the measureName
+      return measureName;
+    }
+  }
+  
   for (key in metrics.counters) {
+    util.log(key);
     if (skipInternalMetrics && (key.match(internalStatsdRe) != null)) {
       continue;
     }

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -319,8 +319,10 @@ var flush_stats = function librato_flush(ts, metrics)
       measurements.push(measure);
       
       // Post MD measurement
-      // TODO Batch support?
-      post_measurements(measureTime, measurements);
+      if (measurements.length >= maxBatchSize) {
+        post_measurements(measureTime, measurements);
+        measurements = [];
+      }
       
     } else {
       if (mType == 'counter') {

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -138,24 +138,41 @@ var post_payload = function(options, proto, payload, retry)
   });
 };
 
-var post_metrics = function(ts, gauges, counters)
+var post_metrics = function(ts, gauges, counters, measurements)
 {
-  var payload = {gauges: gauges,
-                 counters: counters,
-                 measure_time: ts};
-
-  var parsed_host = url_parse(api || 'https://metrics-api.librato.com');
+  var payload = {};
+  var path;
   
-  if (sourceName) {
-    payload.source = sourceName;
+  if (multidimensional) {
+    payload = {
+      time: ts,
+      tags: tags,
+      measurements: measurements
+    };
+    
+    path = "/v1/measurements";
+    
+  } else {
+    payload = {gauges: gauges,
+                   counters: counters,
+                   measure_time: ts};
+
+    
+    if (sourceName) {
+      payload.source = sourceName;
+    }
+    
+    path = "/v1/metrics";
   }
+  
+  var parsed_host = url_parse(api || 'https://metrics-api.librato.com');
   
   payload = JSON.stringify(payload);
 
   var options = {
     host: parsed_host["hostname"],
     port: parsed_host["port"] || 443,
-    path: "/v1/metrics",
+    path: path,
     method: 'POST',
     headers: {
       "Authorization": basicAuthHeader,
@@ -176,44 +193,6 @@ var post_metrics = function(ts, gauges, counters)
 
   post_payload(options, proto, payload, true);
 };
-
-var post_measurements = function(ts, measurements) 
-{
-  var payload = {
-    time: ts,
-    tags: tags,
-    measurements: measurements
-  };
-  
-  var parsed_host = url_parse(api || 'https://metrics-api.librato.com');
-  
-  payload = JSON.stringify(payload);
-
-  var options = {
-    host: parsed_host["hostname"],
-    port: parsed_host["port"] || 443,
-    path: "/v1/measurements",
-    method: 'POST',
-    headers: {
-      "Authorization": basicAuthHeader,
-      "Content-Length": payload.length,
-      "Content-Type": "application/json",
-      "User-Agent" : userAgent
-    }
- };
-
- if (tunnelAgent) {
-   options["agent"] = tunnelAgent;
- }
-
-  var proto = http;
-  if ((parsed_host["protocol"] || 'http:').match(/https/)) {
-    proto = https;
-  }
-
-  post_payload(options, proto, payload, true);
-  
-}
 
 var sanitize_name = function(name)
 {
@@ -337,7 +316,7 @@ var flush_stats = function librato_flush(ts, metrics)
 
       // Post measurements and clear arrays if past batch size
       if (counters.length + gauges.length >= maxBatchSize) {
-        post_metrics(measureTime, gauges, counters);
+        post_metrics(measureTime, gauges, counters, measurements);
         gauges = [];
         counters = [];
       }
@@ -467,12 +446,8 @@ var flush_stats = function librato_flush(ts, metrics)
     }
   }
   
-  if (multidimensional && measurements.length > 0) {
-    post_measurements(measureTime, measurements);
-  } else {
-    if (gauges.length > 0 || counters.length > 0) {
-      post_metrics(measureTime, gauges, counters);
-    }
+  if (gauges.length > 0 || counters.length > 0 || measurements.length > 0) {
+    post_metrics(measureTime, gauges, counters, measurements);
   }
 
 };

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -466,10 +466,15 @@ var flush_stats = function librato_flush(ts, metrics)
                               value: libratoCounters['numStats'].value});
     }
   }
-
-  if (gauges.length > 0 || counters.length > 0) {
-    post_metrics(measureTime, gauges, counters);
+  
+  if (multidimensional && measurements.length > 0) {
+    post_measurements(measureTime, measurements);
+  } else {
+    if (gauges.length > 0 || counters.length > 0) {
+      post_metrics(measureTime, gauges, counters);
+    }
   }
+
 };
 
 var backend_status = function librato_status(writeCb) {

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -150,6 +150,10 @@ var post_metrics = function(ts, gauges, counters)
   if (sourceName) {
     payload.source = sourceName;
   }
+  
+  if (multidimensional) {
+    payload.tags = tags;
+  }
 
   payload = JSON.stringify(payload);
 

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -347,7 +347,6 @@ var flush_stats = function librato_flush(ts, metrics)
   }
   
   for (key in metrics.counters) {
-    util.log(key);
     if (skipInternalMetrics && (key.match(internalStatsdRe) != null)) {
       continue;
     }


### PR DESCRIPTION
This PR adds support for multidimensional metrics in Librato aka tags. There are two major changes:

1) The ability to submit tags globally by setting the config value `tags` equal to a map of tags and values.

2) The ability to submit a stat with a name following the format of `metric.name:value#tag1=value,tag2=value`, where `tag1` and `tag2` will be parsed out and submitted to Librato, as tags, with the respective values. The name format is not set in stone.