### PR TITLE
Support for tagged measurements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Overview
 
 This is a pluggable backend for [StatsD][statsd], which
-publishes stats to [Librato](https://metrics.librato.com).
+publishes stats to [Librato](https://metrics.librato.com). 
 
 ## Requirements
 
@@ -24,8 +24,7 @@ You will need to add the following to your StatsD config file.
 ```js
 librato: {
   email:  "myemail@example.com",
-  token:  "ca98e2bc23b1bfd0cbe9041e824f610491129bb952d52ca4ac22cf3eab5a1c32",
-  source: "unique-per-statsd-instance"
+  token:  "ca98e2bc23b1bfd0cbe9041e824f610491129bb952d52ca4ac22cf3eab5a1c32"
 }
 ```
 
@@ -35,22 +34,17 @@ Example Full Configuration File:
 {
   librato: {
     email:  "myemail@example.com",
-    token:  "ca98e2bc23b1bfd0cbe9041e824f610491129bb952d52ca4ac22cf3eab5a1c32",
-    source: "unique-per-statsd-instance"
+    token:  "ca98e2bc23b1bfd0cbe9041e824f610491129bb952d52ca4ac22cf3eab5a1c32"
   }
   , backends: ["statsd-librato-backend"]
-  , port: 8125
+  , port: 8125,
+  , keyNameSanitize: false
 }
 ```
 
 
 The *email* and *token* settings can be found on your Librato account
-settings page. The *source* is an optional-but-recommended string to
-use as a
-[source](http://support.metrics.librato.com/knowledgebase/articles/47904-what-is-a-source-)
-for all measurements from this statsd instance. This should be unique
-for each statsd process. If unset, the source will default to the
-node's hostname.
+settings page.
 
 ## Enabling
 
@@ -71,17 +65,6 @@ pushed to your Librato account.
 
 The Librato backend also supports the following optional configuration
 options under the top-level `librato` hash:
-
-* `sourceRegex`: An optional JavaScript regular expression to extract
-                 the source name from the metric name. The first
-                 capturing group of the regex is used as the source name,
-                 and everything not matched will be the metric name.
-
-                 Example formats:
-
-                 "SOURCE.METRIC" => /^([^\.]+)\./
-                 "METRIC.SOURCE" => /\.([^\.]+)$/
-                 "server.SOURCE.METRIC" => /^server\.([^\.]+)\./
 
 * `snapTime`: Measurement timestamps are snapped to this interval
               (specified in seconds). This makes it easier to align
@@ -172,32 +155,6 @@ sporadic reports in a variety of ways. Visit the [knowledge base
 article](http://support.metrics.librato.com/knowledgebase/articles/98900-what-if-i-am-reporting-metrics-at-irregular-interv)
 to see how to change the display attributes.
 
-## Setting the source per-metric
-
-All metrics sent by the statsd server will use the source name
-configured in the global configuration file. You can also set a source
-name on a per-stat basis by leveraging the `sourceRegex`
-configuration option. The statsd protocol only supports a single name
-string per stat, so to specify a source name you have to include it
-in the stat name. The `sourceRegex` option sets a regular expression
-filter that splits the source and metric names from the single statsd
-stat name.
-
-For example, to prefix your stat name with a source name separated by
-a period, you would use the `sourceRegex`:
-```
-{
-  sourceRegex: /^([^\.]+)\./
-}
-```
-Sending a stat name of *web-prod-23.api-requests.2xx* would use a metric name
-of *api-requests.2xx* and a source name of *web-prod-23*.
-
-Unfortunately, the set of characters that you can use to delimit
-source from metric is limited to: `[a-zA-Z_\-0-9\.]`. The statsd
-daemon will substitute any characters not in that set before passing
-the stat to the Librato backend.
-
 ## Publishing to Graphite and Librato simultaneously
 
 You can push metrics to Graphite and Librato simultaneously as
@@ -237,28 +194,43 @@ That configuration will proxy requests via a proxy listening on
 localhost on port 8080. You can also use an https proxy by setting the
 protocol to https in the URI.
 
+## Tags
+
+Our backend plugin offers basic tagging support for your metrics you submit to Librato. You can specify what tags you want to submit to Librato using the *tags*
+config in the librato configuration section of the StatsD config file:
+
+
+```js
+{
+  "librato" : {
+    "tags": { "os" : "ubuntu", "host" : "production-web-server-1", ... }
+  }
+}
+```
+
+Once your config has been updated, all metrics submitted to Librato will include your defined tags.
+
+
+We also support tags at the per-stat level should you need more detailed tagging. We provide a naming syntax for your stats so you can submit tags for each stat. That syntax is as follows:
+
+```
+metric.name#tag1=value,tag2=value:value
+```
+
+Starting with a `#`, you would pass in a comma-separated list of tags and we will parse out the tags and values. Given the above example, a stat matching
+the above syntax will be submitted as metric to Librato with a name of `metric.name`, a value of `value` and with the tags `tag1=value` and `tag2=value. You are welcome to use any statsd client of your choosing.
+
+Please note that in order to use tags, the statsd config option `keyNameSanitize` must be set to `false` to properly parse tags out of your stat name.
+
+By default, this functionality is disabled and is newly supported by Librato. If you are interested in using this feature, you send us an email at [support@librato.com](support@librato.com) and request access. 
+
 ## NPM Dependencies
 
 None
 
-## Upgrading from versions prior to 0.1.0
+## Need a version prior to 2.x.x?
 
-If you are upgrading from the statsd-librato-backend before version
-0.1.0, the default representation for counter metrics has
-changed. Starting with 0.1.0, statsd counters are now represented as
-Librato gauges by default. If you were using the default configuration
-prior to 0.1.0, then you may run into conflicts when you try to push
-statsd counter metrics to Librato as gauges. To fix this, you have two
-options:
-
-1) Keep the prior behavior of sending statsd counters as Librato
-counters. Just set the `countersAsGauges` configuration variable to
-*false* in your statsd config.
-
-2) After upgrading to 0.1.0, remove all counter metrics that were
-published by statsd. You can use the API pattern DELETE route to mass
-delete metrics. To delete only counter metrics, add the parameter
-`metric_type=counter`.
+Please use this [branch](https://github.com/librato/statsd-librato-backend/tree/branch-0.1.x).
 
 ## Development
 

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -18,7 +18,9 @@ var   net = require('net'),
 url_parse = require('url').parse,
     https = require('https'),
      http = require('http'),
-       fs = require('fs');
+       fs = require('fs'),
+   extend = require('extend');
+       
 var tunnelAgent = null;
 
 var debug, logAll;
@@ -64,8 +66,18 @@ var globalPrefix = "";
 // So we place such metrics to stoplist
 var brokenMetrics = {};
 
+// Global Measurement tags
+var tags = {};
+
+// Write to legacy
+var writeToLegacy = false;
+
 var post_payload = function(options, proto, payload, retry)
 {
+  if (logAll) {
+    util.log("Sending Payload: " + payload);
+  }
+    
   var req = proto.request(options, function(res) {
     res.on('data', function(d) {
       // Retry 5xx codes
@@ -134,25 +146,24 @@ var post_payload = function(options, proto, payload, retry)
   });
 };
 
-var post_metrics = function(ts, gauges, counters)
+var post_metrics = function(ts, gauges, counters, measurements)
 {
-  var payload = {gauges: gauges,
-                 counters: counters,
-                 measure_time: ts};
-
+  var payload = {};
   var parsed_host = url_parse(api || 'https://metrics-api.librato.com');
-
-
-  if (sourceName) {
-    payload.source = sourceName;
-  }
-
+  var path = "/v1/measurements";
+  
+  payload = {
+    time: ts,
+    tags: tags,
+    measurements: measurements
+  };
+  
   payload = JSON.stringify(payload);
 
   var options = {
     host: parsed_host["hostname"],
     port: parsed_host["port"] || 443,
-    path: '/v1/metrics',
+    path: path,
     method: 'POST',
     headers: {
       "Authorization": basicAuthHeader,
@@ -160,18 +171,29 @@ var post_metrics = function(ts, gauges, counters)
       "Content-Type": "application/json",
       "User-Agent" : userAgent
     }
- };
+  };
 
- if (tunnelAgent) {
+  if (tunnelAgent) {
    options["agent"] = tunnelAgent;
- }
+  }
 
   var proto = http;
   if ((parsed_host["protocol"] || 'http:').match(/https/)) {
     proto = https;
   }
+  
 
   post_payload(options, proto, payload, true);
+  
+  if (writeToLegacy) {
+    payload = {gauges: gauges,
+               counters: counters,
+               measure_time: ts};
+               
+    payload = JSON.stringify(payload);
+    options.path = "/v1/metrics";
+    post_payload(options, proto, payload, true);
+  }
 };
 
 var sanitize_name = function(name)
@@ -192,24 +214,32 @@ var timer_gauge_pct = function(timer_name, values, pct, suffix)
   var min = values[0];
 
   var sum = 0;
-  var sumOfSquares = 0;
+  var names = timer_name.split("#");
+  var name;
 
-  for (var i = 0; i < numInThreshold; i++) {
-    sum += values[i];
-    sumOfSquares += values[i] * values[i];
+  if (names.length > 1) {
+    // We have tags in the timer name i.e. foo#bar=1,baz=2
+    // Take the name before the # so we don't screw up the tag values with the percentile suffix
+    name = names[0];
+  } else {
+    // No tags exist in the timer name
+    name = timer_name;
   }
-
-  var name = timer_name;
 
   if (suffix) {
     name += suffix;
   }
 
+  // Rejoin everything back together if we had tags
+  if (names.length > 1) {
+    names[0] = name + "#";
+    name = names.join();
+  } 
+
   return {
     name: name,
     count: numInThreshold,
     sum: sum,
-    sum_squares: sumOfSquares,
     min: min,
     max: max
   };
@@ -219,8 +249,14 @@ var flush_stats = function librato_flush(ts, metrics)
 {
   var numStats = 0, statCount;
   var key;
+  
+  // Librato SD Metrics
   var counters = [];
   var gauges = [];
+  
+  // Librato MD Metrics
+  var measurements = []; 
+  
   var measureTime = ts;
   var internalStatsdRe = /^statsd\./;
 
@@ -251,12 +287,15 @@ var flush_stats = function librato_flush(ts, metrics)
 
   var addMeasure = function add_measure(mType, measure, countStat) {
     countStat = typeof countStat !== 'undefined' ? countStat : true;
-
+    
     var match;
     var measureName = globalPrefix + measure.name;
+    
+    measure.tags = {};
+    measureName = parse_and_set_tags(measureName, measure);
 
     // Use first capturing group as source name
-    if (sourceRegex && (match = measureName.match(sourceRegex)) && match[1]) {
+    if (!writeToLegacy && sourceRegex && (match = measureName.match(sourceRegex)) && match[1]) {
       measure.source = sanitize_name(match[1]);
       // Remove entire matching string from the measure name & add global prefix.
       measure.name = sanitize_name(measureName.slice(0, match.index) + measureName.slice(match.index + match[0].length));
@@ -267,25 +306,55 @@ var flush_stats = function librato_flush(ts, metrics)
     if (brokenMetrics[measure.name]) {
       return;
     }
-
-    if (mType == 'counter') {
-      counters.push(measure);
-    } else {
-      gauges.push(measure);
+    
+    measurements.push(measure);
+    
+    if (writeToLegacy) {
+      if (mType == 'counter') {
+        counters.push(measure);
+      } else {
+        gauges.push(measure);
+      }
     }
-
-    if (countStat) {
-      numStats += 1;
-    }
-
+    
     // Post measurements and clear arrays if past batch size
-    if (counters.length + gauges.length >= maxBatchSize) {
-      post_metrics(measureTime, gauges, counters);
-      gauges = [];
-      counters = [];
+    if (measurements >= maxBatchSize || (writeToLegacy && (counters.length + gauges.length >= maxBatchSize)) ) {
+      post_metrics(measureTime, gauges, counters, measurements);
+      
+      if (measurements >= maxBatchSize) {
+        measurements = [];
+      }
+      
+      if (counters.length + gauges.length >= maxBatchSize) {
+        gauges = [];
+        counters = [];
+      }
     }
   };
-
+  
+  var parse_and_set_tags = function (measureName, measure) {
+    // Valid format for parsing tags out: global-prefix.name#tag1=value,tag2=value
+    // NOTE: Name can include the source
+    var vals = measureName.split("#")
+    if (vals.length > 1) {
+      // Found tags in the measureName. Parse them out and return the measureName without the tags.
+      measureName = vals.shift();
+      rawTags = vals.pop().split(",");
+      rawTags.forEach(function(rawTag) {
+        var name = rawTag.split("=").shift();
+        var value = rawTag.split("=").pop();
+        if (name.length && value.length) {
+          measure.tags[name] = value;
+        }
+      });
+      
+      return measureName;
+    } else {
+      // No tags existed in the measureName
+      return measureName;
+    }
+  }
+  
   for (key in metrics.counters) {
     if (skipInternalMetrics && (key.match(internalStatsdRe) != null)) {
       continue;
@@ -407,10 +476,11 @@ var flush_stats = function librato_flush(ts, metrics)
                               value: libratoCounters['numStats'].value});
     }
   }
-
-  if (gauges.length > 0 || counters.length > 0) {
-    post_metrics(measureTime, gauges, counters);
+  
+  if (gauges.length > 0 || counters.length > 0 || measurements.length > 0) {
+    post_metrics(measureTime, gauges, counters, measurements);
   }
+
 };
 
 var backend_status = function librato_status(writeCb) {
@@ -545,6 +615,19 @@ exports.init = function librato_init(startup_time, config, events, logger)
     if(config.librato.globalPrefix) {
       globalPrefix = config.librato.globalPrefix + '.';
     }
+    
+    // Set global measurement tags if they are defined.
+    if (config.librato.tags && Object.keys(config.librato.tags).length) {
+      tags = config.librato.tags;
+    }
+    
+    // Set global measurement tags if they are defined.
+    if (config.librato.writeToLegacy && Object.keys(config.librato.writeToLegacy).length) {
+      writeToLegacy = config.librato.writeToLegacy;
+    }
+    
+    // Set host as a global tag
+    tags['host'] = sourceName;
   }
 
   if (!email || !token) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "engines": {
     "node": ">=0.8"
   },
-  "dependencies": {},
+  "dependencies": {
+    "extend": "^3.0.0"
+  },
   "devDependencies": {},
   "main": "lib/librato.js",
   "scripts": {

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -35,8 +35,9 @@ module.exports = {
         req.on('end', function() {
           var body = JSON.parse(data),
               gauges = {};
-          for (var k in body.gauges) {
-            gauges[body.gauges[k].name] = body.gauges[k].value;
+              
+          for (var k in body.measurements) {
+            gauges[body.measurements[k].name] = body.measurements[k].value;
           }
           if (reject_metric) {
             test.ok(gauges.bad_counter);
@@ -61,9 +62,11 @@ module.exports = {
               server.once('request', api_mock(false));
               emitter.emit('flush', 123, metrics);
             }, 100);
+            
           } else {
             res.writeHead(200, {});
             res.end('');
+            
 
             test.strictEqual(gauges.bad_counter, undefined);
             test.ok(gauges.cool_gauge);
@@ -79,7 +82,7 @@ module.exports = {
       librato: {
         email: '-@-',
         token: '-',
-        api: 'http://127.0.0.1:' + server_port
+        api: 'http://127.0.0.1:' + server_port,
       }
     }, emitter);
 


### PR DESCRIPTION
This PR adds support for measurements with tags in Librato. By default, measurements will be submitted to Librato's new API that supports tagging. We are also two config options:
- `tags` is a config option that lets you specify global tags for all measurements submitted to Librato. The `sourceName` regex will continue to function but will now be submitted for all measurements as a global tag named `source`. By default, this value is `{}`.
- `writeToLegacy` is a config option that will let you write to the legacy Librato API endpoint. This is designed to help users transition to Librato's new API and can be switched off once they are ready. By default, this value is `true`.

Librato will be adding official statsd clients, over time, to support tagging. However, it is possible to submit a stat in its "raw" format using the following syntax for its name:

`metric.name:value#tag1=value,tag2=value`

In the above example, 'tag1' and 'tag2' will be parsed out and submitted to Librato with the respective values for the given stat.

cc @jderrett 
