### PR TITLE
Enhancement: bootstrap config and start statsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,21 @@ published by statsd. You can use the API pattern DELETE route to mass
 delete metrics. To delete only counter metrics, add the parameter
 `metric_type=counter`.
 
+## Docker
+
+You may use `bin/statsd-librato` to easily bootstrap the daemon inside
+a container.
+
+Invoking this via `CMD` or `ENTRYPOINT` will create a simple
+configuration and run the statsd daemon with this backend enabled,
+listening on `8125`.
+
+The following environment variables are available to customize:
+
+ - `LIBRATO_EMAIL`
+ - `LIBRATO_TOKEN`
+ - `LIBRATO_SOURCE`
+
 ## Development
 
 - [Librato Backend](https://github.com/librato/statsd-librato-backend)

--- a/bin/statsd-librato
+++ b/bin/statsd-librato
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+var fs = require('fs'),
+  rootPath = require('path').resolve(__dirname, './../../..');
+
+if (!fs.existsSync(rootPath + '/stats.js')) {
+  console.error('This should run as a dependency inside etsy/statsd');
+  if (process.env.DEBUG) {
+    console.log('rootPath: ' + rootPath);
+    console.log('__dirname: ' + __dirname);
+  }
+  process.exit(1);
+}
+
+var configPath = rootPath + '/config.js';
+
+if (!fs.existsSync(configPath)) {
+  var configFile = '';
+  configFile += '{' + "\n";
+  configFile += "  librato: {\n";
+  configFile += "    email: process.env.LIBRATO_EMAIL || 'default',\n";
+  configFile += "    token: process.env.LIBRATO_TOKEN || 'token',\n";
+  configFile += "    source: process.env.LIBRATRO_SOURCE || 'env'\n";
+  configFile += '  },' + "\n";
+  configFile += "  backends: [\"statsd-librato-backend\"],\n";
+  configFile += "  port: 8125\n";
+  configFile += '}';
+
+  fs.writeFileSync(configPath, configFile, 'utf-8');
+}
+
+require(rootPath + '/bin/statsd');

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "main": "lib/librato.js",
   "scripts": {
     "test": "nodeunit test"
+  },
+  "bin": {
+    "statsd-librato": "./bin/statsd-librato"
   }
 }


### PR DESCRIPTION
## Provides wrapper script

 - creates a `config.js` if non exists
 - uses env variables to provide email, token and source

I am dockerizing our StatsD+Librato setup and felt like a `CMD` that uses environment variables to create a config file, etc. would a good idea. Do you have any interest in this?

