### PR TITLE
Allow to disable hostname

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -635,8 +635,10 @@ exports.init = function librato_init(startup_time, config, events, logger)
       writeToLegacy = config.librato.writeToLegacy;
     }
     
-    // Set host as a global tag. Defaults to os.hostname()
-    tags.host = hostName;
+    // Set host as a global tag. Defaults to os.hostname(). Can be disabled by setting host to false.
+    if (hostName) {
+      tags.host = hostName;
+    }
   }
 
   if (!email || !token) {


### PR DESCRIPTION
This allows to disable sending a host tag by setting the host to `false`.

This helps in cases where statsd is not running on the same instance the tracked application is running.