### PR TITLE
Fix bad copy-paste for writeToLegacy check

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -630,8 +630,8 @@ exports.init = function librato_init(startup_time, config, events, logger)
       tags = config.librato.tags;
     }
     
-    // Set global measurement tags if they are defined.
-    if (config.librato.writeToLegacy && Object.keys(config.librato.writeToLegacy).length) {
+    // Write metrics to legacy API
+    if (config.librato.writeToLegacy) {
       writeToLegacy = config.librato.writeToLegacy;
     }
     


### PR DESCRIPTION
Follow up from https://github.com/librato/statsd-librato-backend/pull/65.

Looks like we had some bad copy-paste around the `writeToLegacy` config value.