### PR TITLE
Avoid crash when measure time is too far in the past

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -104,7 +104,7 @@ var post_payload = function(options, proto, payload, retry)
         if (/^application\/json/.test(res.headers['content-type'])) {
           var meta = JSON.parse(d),
               re = /'([^']+)' is a \S+, but was submitted as different type/;
-          if (meta.errors && meta.errors.params && meta.errors.params.type.length) {
+          if (meta.errors && meta.errors.params && meta.errors.params.type && meta.errors.params.type.length) {
             var fields = meta.errors.params.type;
             for (var i=0; i < fields.length; i++) {
               var match  = re.exec(fields[i]),


### PR DESCRIPTION
If the API responds with an HTTP 400 because the measure time is too far in the past it crashes the entire statsd server.

```
3 Mar 21:45:46 - LOG_ERR: Failed to post to Librato: HTTP 400: {"errors":{"params":{"measure_time":["is too far in the past"]}},"request_time":1488585496}
/statsd/node_modules/statsd-librato-backend/lib/librato.js:95
          if (meta.errors && meta.errors.params && meta.errors.params.type.length) {
                                                                          ^

TypeError: Cannot read property 'length' of undefined
    at IncomingMessage.<anonymous> (/statsd/node_modules/statsd-librato-backend/lib/librato.js:95:75)
    at emitOne (events.js:96:13)
    at IncomingMessage.emit (events.js:188:7)
    at IncomingMessage.Readable.read (_stream_readable.js:381:10)
    at flow (_stream_readable.js:761:34)
    at resume_ (_stream_readable.js:743:3)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

This additional checks fixes this error.