### PR TITLE
Fix invalid legacy payloads

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -192,6 +192,7 @@ var post_metrics = function(ts, gauges, counters, measurements)
                
     payload = JSON.stringify(payload);
     options.path = "/v1/metrics";
+    options.headers["Content-Length"] = payload.length
     post_payload(options, proto, payload, true);
   }
 };
@@ -294,7 +295,8 @@ var flush_stats = function librato_flush(ts, metrics)
     measure.tags = {};
     measureName = parse_and_set_tags(measureName, measure);
 
-    // Use first capturing group as source name
+    // Use first capturing group as source name.
+    // NOTE: Only legacy users will a) have a source and b) have a source set by regex
     if (sourceRegex && (match = measureName.match(sourceRegex)) && match[1]) {
       measure.source = sanitize_name(match[1]);
       // Remove entire matching string from the measure name & add global prefix.
@@ -315,15 +317,26 @@ var flush_stats = function librato_flush(ts, metrics)
       return;
     }
     
-    measurements.push(measure);
-    
     if (writeToLegacy) {
+      // Remove the tags
+      var legacyMeasure = {};
+      extend(legacyMeasure, measure);
+      delete legacyMeasure.tags;
+      
+      // Set the source if there isn't one pulled from the regex
+      if (!legacyMeasure.source) {
+        legacyMeasure.source = sourceName
+      }
+
       if (mType == 'counter') {
-        counters.push(measure);
+        counters.push(legacyMeasure);
       } else {
-        gauges.push(measure);
+        gauges.push(legacyMeasure);
       }
     }
+    
+    // Add the payload
+    measurements.push(measure);
     
     // Post measurements and clear arrays if past batch size
     if (measurements >= maxBatchSize || (writeToLegacy && (counters.length + gauges.length >= maxBatchSize)) ) {


### PR DESCRIPTION
For legacy users on 2.0+, the payload being sent to Librato includes a `tags` attribute, an incorrect length for the `Content-Length` header and, in some cases, it would be missing a`source` attribute. This would result in invalid legacy payloads.

Example of proper payload (second one being a legacy payload):

```
13 Mar 14:55:48 - DEBUG: Sending Payload: {"time":1489434940,"tags":{"os":"el capitan","host":"Bryans-Work-MacBook-Pro.local"},"measurements":[{"name":"bryan","value":0,"tags":{"source":"digital-ocean-nyc-3"}}]}
13 Mar 14:55:48 - DEBUG: Sending Payload: {"gauges":[{"name":"bryan","value":0,"source":"digital-ocean-nyc-3"}],"counters":[],"measure_time":1489434940}
```