### PR TITLE
Move to CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "0.10"
-  - "0.8"
-before_script:
-  - npm install -g nodeunit


### PR DESCRIPTION
Librato, internally, uses CircleCI for all our repos. This removes TravisCI builds from this repo.