### PR TITLE
Bring travis back. Update build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js: ["7", "6", "5", "4", "0.12"]
 before_script:
   - npm install -g nodeunit
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js: ["7", "6", "5", "4", "0.12"]
+before_script:
+  - npm install -g nodeunit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # StatsD Librato backend
 
 [![NPM version](https://badge.fury.io/js/statsd-librato-backend.svg)](http://badge.fury.io/js/statsd-librato-backend)
-[![CircleCI](https://circleci.com/gh/librato/statsd-librato-backend.svg?style=shield)](https://circleci.com/gh/librato/statsd-librato-backend)
+[![Build Status](https://travis-ci.org/librato/statsd-librato-backend.svg?branch=master)](https://travis-ci.org/librato/statsd-librato-backend)
 
 ---
 


### PR DESCRIPTION
We need to do a better job testing this library against the major versions of Node. CircleCI is limited on their build functionality, so back to Travis we go, essentially reverting https://github.com/librato/statsd-librato-backend/pull/74

The versions of node we are going to build against:
- Everything post io.js merge
- Last major build before io.js merge