### PR TITLE
Add eslint support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "google"
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
       "quotes": ["off", "double"],
       "no-var": "off",
       "max-len": "warn",
-      "guard-for-in": "warn"
+      "guard-for-in": "warn",
+      "eqeqeq": "warn"
     },
     "extends": "google"
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,13 @@
 {
+    "parserOptions": {
+      "ecmaVersion": 6
+    },
+    "rules": {
+      "one-var-declaration-per-line": "error",
+      "quotes": ["off", "double"],
+      "no-var": "off",
+      "max-len": "warn",
+      "guard-for-in": "warn"
+    },
     "extends": "google"
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     },
     "rules": {
       "one-var-declaration-per-line": "error",
-      "quotes": ["off", "double"],
+      "quotes": ["error", "single"],
       "no-var": "off",
       "max-len": "warn",
       "guard-for-in": "warn",

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -1,5 +1,4 @@
-/*jslint node: true, white: true, sloppy: true */
-
+/* jslint node: true, white: true, sloppy: true */
 /*
  * Flushes stats to Librato Metrics (https://metrics.librato.com).
  *
@@ -12,110 +11,93 @@
  * statsd configuration file under the sub-hash key 'librato'. See the
  * README in this repository for available configuration options.
  */
-
-var   net = require('net'),
-     util = require('util'),
-url_parse = require('url').parse,
-    https = require('https'),
-     http = require('http'),
-       fs = require('fs'),
-   extend = require('extend');
-       
+var util = require('util');
+var urlParse = require('url').parse;
+var https = require('https');
+var http = require('http');
+var fs = require('fs');
+var extend = require('extend');
 var tunnelAgent = null;
-
-var debug, logAll;
-var api, email, token, period, sourceName, hostName, sourceRegex, includeMetrics, excludeMetrics;
-
+var logAll;
+var api;
+var email;
+var token;
+var sourceName;
+var hostName;
+var sourceRegex;
+var includeMetrics;
+var excludeMetrics;
 // How long to wait before retrying a failed post, in seconds
 var retryDelaySecs = 5;
-
 // Timeout for POSTs, in seconds
 var postTimeoutSecs = 4;
-
 var libratoStats = {};
 var userAgent;
 var basicAuthHeader;
 var flushInterval;
-
 // Maximum measurements we send in a single post
 var maxBatchSize = 500;
-
 // What epoch interval to align time stamps to (defaults to flush interval)
 var snapTime = null;
-
 // Counters as pushed as gauge increments.
 var countersAsGauges = true;
-
 // Do we skip publishing internal statsd metrics.
 //
 var skipInternalMetrics = true;
-
 // Statsd counters reset, we want monotonically increasing
 // counters.
 var libratoCounters = {};
-
 // Do we always suffix 100 percentile with .100
 // e.g. metric_name.100
 var alwaysSuffixPercentile = false;
-
 // A string to prepend to all measurement names sent to Librato.
-var globalPrefix = "";
-
+var globalPrefix = '';
 // Librato web service can't ignore individual broken metrics
 // instead it's dropping whole payloads
 // So we place such metrics to stoplist
 var brokenMetrics = {};
-
 // Global Measurement tags
 var tags = {};
-
 // Write to legacy
 var writeToLegacy = false;
-
-var post_payload = function(options, proto, payload, retry)
-{
+var postPayload = function(options, proto, payload, retry) {
   if (logAll) {
-    util.log("Sending Payload: " + payload);
+    util.log('Sending Payload: ' + payload);
   }
-    
   var req = proto.request(options, function(res) {
     res.on('data', function(d) {
       // Retry 5xx codes
-      if (Math.floor(res.statusCode / 100) == 5){
-        var errdata = "HTTP " + res.statusCode + ": " + d;
-        if (retry){
+      if (Math.floor(res.statusCode / 100) == 5) {
+        var errdata = 'HTTP ' + res.statusCode + ': ' + d;
+        if (retry) {
           if (logAll) {
-            util.log("Failed to post to Librato: " + errdata, "LOG_ERR");
+            util.log('Failed to post to Librato: ' + errdata, 'LOG_ERR');
           }
           setTimeout(function() {
-            post_payload(options, proto, payload, false);
+            postPayload(options, proto, payload, false);
           }, retryDelaySecs * 1000);
         } else {
-          util.log("Failed to connect to Librato: " + errdata, "LOG_ERR");
+          util.log('Failed to connect to Librato: ' + errdata, 'LOG_ERR');
         }
       }
-
       // Log 4xx errors
-      if (Math.floor(res.statusCode / 100) == 4){
-        var errdata = "HTTP " + res.statusCode + ": " + d;
+      if (Math.floor(res.statusCode / 100) == 4) {
+        var errdata = 'HTTP ' + res.statusCode + ': ' + d;
         if (logAll) {
-          util.log("Failed to post to Librato: " + errdata, "LOG_ERR");
+          util.log('Failed to post to Librato: ' + errdata, 'LOG_ERR');
         }
         if (/^application\/json/.test(res.headers['content-type'])) {
-          var meta = JSON.parse(d),
-              re = /'([^']+)' is a \S+, but was submitted as different type/;
+          var meta = JSON.parse(d);
+          var re = /'([^']+)' is a \S+, but was submitted as different type/;
           if (meta.errors && meta.errors.params && meta.errors.params.type && meta.errors.params.type.length) {
             var fields = meta.errors.params.type;
-            for (var i=0; i < fields.length; i++) {
-              var match  = re.exec(fields[i]),
-                  field = match && match[1];
+            for (var i = 0; i < fields.length; i++) {
+              var match = re.exec(fields[i]);
+              var field = match && match[1];
               if (field && !brokenMetrics[field]) {
                 brokenMetrics[field] = true;
                 if (logAll) {
-                  util.log(
-                    "Placing metric '" + field + "' to stoplist until service restart",
-                    "LOG_ERR"
-                  );
+                  util.log('Placing metric \'' + field + '\' to stoplist until service restart', 'LOG_ERR');
                 }
               }
             }
@@ -124,437 +106,369 @@ var post_payload = function(options, proto, payload, retry)
       }
     });
   });
-
   req.setTimeout(postTimeoutSecs * 1000, function(request) {
     if (logAll) {
-      util.log("Timed out sending metrics to Librato", "LOG_ERR");
+      util.log('Timed out sending metrics to Librato', 'LOG_ERR');
     }
     req.end();
   });
   req.write(payload);
   req.end();
-
-  libratoStats['last_flush'] = Math.round(new Date().getTime() / 1000);
+  libratoStats.last_flush = Math.round(new Date().getTime() / 1000);
   req.on('error', function(errdata) {
-    if (retry){
+    if (retry) {
       setTimeout(function() {
-        post_payload(options, proto, payload, false);
+        postPayload(options, proto, payload, false);
       }, retryDelaySecs * 1000);
     } else {
-      util.log("Failed to connect to Librato: " + errdata, "LOG_ERR");
+      util.log('Failed to connect to Librato: ' + errdata, 'LOG_ERR');
     }
   });
 };
-
-var post_metrics = function(ts, gauges, counters, measurements)
-{
+var postMetrics = function(ts, gauges, counters, measurements) {
   var payload = {};
-  var parsed_host = url_parse(api || 'https://metrics-api.librato.com');
-  var path = "/v1/measurements";
-  
+  var parsedHost = urlParse(api || 'https://metrics-api.librato.com');
+  var path = '/v1/measurements';
   payload = {
     time: ts,
     tags: tags,
-    measurements: measurements
+    measurements: measurements,
   };
-  
   payload = JSON.stringify(payload);
-
   var options = {
-    host: parsed_host["hostname"],
-    port: parsed_host["port"] || 443,
+    host: parsedHost.hostname,
+    port: parsedHost.port || 443,
     path: path,
     method: 'POST',
     headers: {
-      "Authorization": basicAuthHeader,
-      "Content-Length": payload.length,
-      "Content-Type": "application/json",
-      "User-Agent" : userAgent
-    }
+      'Authorization': basicAuthHeader,
+      'Content-Length': payload.length,
+      'Content-Type': 'application/json',
+      'User-Agent': userAgent,
+    },
   };
-
   if (tunnelAgent) {
-   options["agent"] = tunnelAgent;
+    options.agent = tunnelAgent;
   }
-
   var proto = http;
-  if ((parsed_host["protocol"] || 'http:').match(/https/)) {
+  if ((parsedHost.protocol || 'http:').match(/https/)) {
     proto = https;
   }
-  
-
-  post_payload(options, proto, payload, true);
-  
+  postPayload(options, proto, payload, true);
   if (writeToLegacy) {
-    payload = {gauges: gauges,
-               counters: counters,
-               measure_time: ts};
-               
+    payload = {
+      gauges: gauges,
+      counters: counters,
+      measure_time: ts,
+    };
     payload = JSON.stringify(payload);
-    options.path = "/v1/metrics";
-    options.headers["Content-Length"] = payload.length
-    post_payload(options, proto, payload, true);
+    options.path = '/v1/metrics';
+    options.headers['Content-Length'] = payload.length;
+    postPayload(options, proto, payload, true);
   }
 };
-
-var sanitize_name = function(name)
-{
-  return name.replace(/[^-.:_\w]+/g, '_').substr(0,255)
+var sanitizeName = function(name) {
+  return name.replace(/[^-.:_\w]+/g, '_').substr(0, 255);
 };
-
-var timer_gauge_pct = function(timer_name, values, pct, suffix)
-{
-  var thresholdIndex = Math.round(((100 - pct) / 100) * values.length);
+var timerGaugePct = function(timerName, values, pct, suffix) {
+  var thresholdIndex = Math.round((100 - pct) / 100 * values.length);
   var numInThreshold = values.length - thresholdIndex;
-
   if (numInThreshold <= 0) {
     return null;
   }
-
   var max = values[numInThreshold - 1];
   var min = values[0];
-
-  var sum = values.slice(0, numInThreshold).reduce(function (s, current) {
+  var sum = values.slice(0, numInThreshold).reduce(function(s, current) {
     return s + current;
   }, 0);
-  var names = timer_name.split("#");
+  var names = timerName.split('#');
   var name;
-
   if (names.length > 1) {
     // We have tags in the timer name i.e. foo#bar=1,baz=2
     // Take the name before the # so we don't screw up the tag values with the percentile suffix
     name = names[0];
   } else {
     // No tags exist in the timer name
-    name = timer_name;
+    name = timerName;
   }
-
   if (suffix) {
     name += suffix;
   }
-
   // Rejoin everything back together if we had tags
   if (names.length > 1) {
-    names[0] = name + "#";
+    names[0] = name + '#';
     name = names.join();
-  } 
-
+  }
   return {
     name: name,
     count: numInThreshold,
     sum: sum,
     min: min,
-    max: max
+    max: max,
   };
-}
-
-var flush_stats = function librato_flush(ts, metrics)
-{
-  var numStats = 0, statCount;
+};
+var flushStats = function libratoFlush(ts, metrics) {
+  var numStats = 0;
+  var statCount;
   var key;
-  
   // Librato SD Metrics
   var counters = [];
   var gauges = [];
-  
   // Librato MD Metrics
-  var measurements = []; 
-  
+  var measurements = [];
   var measureTime = ts;
   var internalStatsdRe = /^statsd\./;
-
-
   if (snapTime) {
     measureTime = Math.floor(ts / snapTime) * snapTime;
   }
-
-  var excludeMetric = function (metric) {
-      var matchesFilter = false;
-      for (var index = 0; index < includeMetrics.length; index++) {
-          if (includeMetrics[index].test(metric)) {
-              matchesFilter = true;
-              break;
-          }
+  var excludeMetric = function(metric) {
+    var matchesFilter = false;
+    for (var index = 0; index < includeMetrics.length; index++) {
+      if (includeMetrics[index].test(metric)) {
+        matchesFilter = true;
+        break;
       }
-
-      var matchesExclude = false;
-      for (var index = 0; index < excludeMetrics.length; index++) {
-          if (excludeMetrics[index].test(metric)) {
-              matchesExclude = true;
-              break;
-          }
+    }
+    var matchesExclude = false;
+    for (var index = 0; index < excludeMetrics.length; index++) {
+      if (excludeMetrics[index].test(metric)) {
+        matchesExclude = true;
+        break;
       }
-
-      return ((includeMetrics.length > 0) && !matchesFilter) || matchesExclude;
-  }
-
-  var addMeasure = function add_measure(mType, measure, countStat) {
+    }
+    return includeMetrics.length > 0 && !matchesFilter || matchesExclude;
+  };
+  var addMeasure = function addMeasure(mType, measure, countStat) {
     countStat = typeof countStat !== 'undefined' ? countStat : true;
-    
     var match;
     var measureName = globalPrefix + measure.name;
-    
     measure.tags = {};
-    measureName = parse_and_set_tags(measureName, measure);
-
+    measureName = parseAndSetTags(measureName, measure);
     // Use first capturing group as source name.
     // NOTE: Only legacy users will a) have a source and b) have a source set by regex
     if (sourceRegex && (match = measureName.match(sourceRegex)) && match[1]) {
-      measure.source = sanitize_name(match[1]);
+      measure.source = sanitizeName(match[1]);
       // Remove entire matching string from the measure name & add global prefix.
-      measure.name = sanitize_name(measureName.slice(0, match.index) + measureName.slice(match.index + match[0].length));
-
+      measure.name = sanitizeName(measureName.slice(0, match.index) + measureName.slice(match.index + match[0].length));
       // Create a measurement-level tag named source
       measure.tags.source = measure.source;
     } else {
-      measure.name = sanitize_name(measureName);
-
+      measure.name = sanitizeName(measureName);
       // Use the global config sourceName as a source tag, if it exists.
       if (sourceName !== null) {
         measure.tags.source = sourceName;
       }
     }
-
     if (brokenMetrics[measure.name]) {
       return;
     }
-    
     if (writeToLegacy) {
       // Remove the tags
       var legacyMeasure = {};
       extend(legacyMeasure, measure);
       delete legacyMeasure.tags;
-      
       // Set the source if there isn't one pulled from the regex
       if (!legacyMeasure.source) {
-        legacyMeasure.source = sourceName
+        legacyMeasure.source = sourceName;
       }
-
       if (mType == 'counter') {
         counters.push(legacyMeasure);
       } else {
         gauges.push(legacyMeasure);
       }
     }
-    
     // Add the payload
     measurements.push(measure);
-    
     // Post measurements and clear arrays if past batch size
-    if (measurements >= maxBatchSize || (writeToLegacy && (counters.length + gauges.length >= maxBatchSize)) ) {
+    if (measurements >= maxBatchSize || writeToLegacy && counters.length + gauges.length >= maxBatchSize) {
       post_metrics(measureTime, gauges, counters, measurements);
-      
       if (measurements >= maxBatchSize) {
         measurements = [];
       }
-      
       if (counters.length + gauges.length >= maxBatchSize) {
         gauges = [];
         counters = [];
       }
     }
   };
-  
-  var parse_and_set_tags = function (measureName, measure) {
+  var parseAndSetTags = function(measureName, measure) {
     // Valid format for parsing tags out: global-prefix.name#tag1=value,tag2=value
     // NOTE: Name can include the source
-    var vals = measureName.split("#")
+    var vals = measureName.split('#');
     if (vals.length > 1) {
       // Found tags in the measureName. Parse them out and return the measureName without the tags.
       measureName = vals.shift();
-      rawTags = vals.pop().split(",");
+      rawTags = vals.pop().split(',');
       rawTags.forEach(function(rawTag) {
-        var name = rawTag.split("=").shift();
-        var value = rawTag.split("=").pop();
+        var name = rawTag.split('=').shift();
+        var value = rawTag.split('=').pop();
         if (name.length && value.length) {
           measure.tags[name] = value;
         }
       });
-      
       return measureName;
     } else {
       // No tags existed in the measureName
       return measureName;
     }
-  }
-  
+  };
   for (key in metrics.counters) {
-    if (skipInternalMetrics && (key.match(internalStatsdRe) != null)) {
+    if (skipInternalMetrics && key.match(internalStatsdRe) != null) {
       continue;
     }
     if (excludeMetric(key)) {
       continue;
     }
-
     if (countersAsGauges) {
-      addMeasure('gauge', { name: key,
-                            value: metrics.counters[key]});
+      addMeasure('gauge', {
+        name: key,
+        value: metrics.counters[key],
+      });
       continue;
     }
-
     if (!libratoCounters[key]) {
-      libratoCounters[key] = {value: metrics.counters[key],
-                              lastUpdate: ts};
+      libratoCounters[key] = {
+        value: metrics.counters[key],
+        lastUpdate: ts,
+      };
     } else {
       libratoCounters[key].value += metrics.counters[key];
       libratoCounters[key].lastUpdate = ts;
     }
-
-    addMeasure('counter', { name: key,
-                            value: libratoCounters[key].value});
+    addMeasure('counter', {
+      name: key,
+      value: libratoCounters[key].value,
+    });
   }
-
   for (key in metrics.timers) {
     if (metrics.timers[key].length == 0) {
       continue;
     }
-    if (skipInternalMetrics && (key.match(internalStatsdRe) != null)) {
+    if (skipInternalMetrics && key.match(internalStatsdRe) != null) {
       continue;
     }
     if (excludeMetric(key)) {
       continue;
     }
-
-    var sortedVals = metrics.timers[key].sort(
-      function (a, b) { return a - b; }
-    );
-
-
+    var sortedVals = metrics.timers[key].sort(function(a, b) {
+      return a - b;
+    });
     // First build the 100% percentile
-    var gauge = timer_gauge_pct(
-      key,
-      sortedVals,
-      100,
-      alwaysSuffixPercentile ? '.100' : null
-    );
-
+    var gauge = timerGaugePct(key, sortedVals, 100, alwaysSuffixPercentile ? '.100' : null);
     if (gauge) {
       addMeasure('gauge', gauge);
     }
-
     // Now for each percentile
     var pKey;
     for (pKey in metrics.pctThreshold) {
       var pct = metrics.pctThreshold[pKey];
-
-      gauge = timer_gauge_pct(key, sortedVals, pct, "." + pct);
+      gauge = timerGaugePct(key, sortedVals, pct, '.' + pct);
       if (gauge) {
         // Percentiles are not counted in numStats
         addMeasure('gauge', gauge, false);
       }
     }
-
-    var timer_data = metrics.timer_data[key];
-    if (timer_data != null) {
-      var histogram = timer_data.histogram;
+    var timerData = metrics.timer_data[key];
+    if (timerData != null) {
+      var histogram = timerData.histogram;
       if (histogram != null) {
         var bin;
         for (bin in histogram) {
           var name = key + '.' + bin;
           // Bins are not counted in numStats
-          addMeasure('gauge', { name: name,
-                                value: histogram[bin]}, false);
+          addMeasure('gauge', {
+            name: name,
+            value: histogram[bin],
+          }, false);
         }
       }
     }
   }
-
   for (key in metrics.gauges) {
-    if (skipInternalMetrics && (key.match(internalStatsdRe) != null)) {
+    if (skipInternalMetrics && key.match(internalStatsdRe) != null) {
       continue;
     }
     if (excludeMetric(key)) {
       continue;
     }
-
-    addMeasure('gauge', { name: key,
-                          value: metrics.gauges[key]});
+    addMeasure('gauge', {
+      name: key,
+      value: metrics.gauges[key],
+    });
   }
-
   for (key in metrics.sets) {
-    if (skipInternalMetrics && (key.match(internalStatsdRe) != null)) {
+    if (skipInternalMetrics && key.match(internalStatsdRe) != null) {
       continue;
     }
-
-    addMeasure('gauge', { name: key,
-                          value: metrics.sets[key].values().length });
+    addMeasure('gauge', {
+      name: key,
+      value: metrics.sets[key].values().length,
+    });
   }
-
   statCount = numStats;
-
   if (!skipInternalMetrics) {
     if (countersAsGauges) {
-      addMeasure('gauge', { name: 'numStats',
-                            value: statCount});
+      addMeasure('gauge', {
+        name: 'numStats',
+        value: statCount,
+      });
     } else {
-      if (libratoCounters['numStats']) {
-        libratoCounters['numStats'].value += statCount;
-        libratoCounters['numStats'].lastUpdate = ts;
+      if (libratoCounters.numStats) {
+        libratoCounters.numStats.value += statCount;
+        libratoCounters.numStats.lastUpdate = ts;
       } else {
-        libratoCounters['numStats'] = {value: statCount,
-                                       lastUpdate: ts};
+        libratoCounters.numStats = {
+          value: statCount,
+          lastUpdate: ts,
+        };
       }
-
-      addMeasure('counter', { name: 'numStats',
-                              value: libratoCounters['numStats'].value});
+      addMeasure('counter', {
+        name: 'numStats',
+        value: libratoCounters.numStats.value,
+      });
     }
   }
-  
   if (gauges.length > 0 || counters.length > 0 || measurements.length > 0) {
-    post_metrics(measureTime, gauges, counters, measurements);
+    postMetrics(measureTime, gauges, counters, measurements);
   }
-
 };
-
-var backend_status = function librato_status(writeCb) {
+var backendStatus = function libratoStatus(writeCb) {
   for (stat in libratoStats) {
     writeCb(null, 'librato', stat, libratoStats[stat]);
   }
 };
-
-var build_basic_auth = function(email, token)
-{
+var buildBasicAuth = function(email, token) {
   return 'Basic ' + new Buffer(email + ':' + token).toString('base64');
-}
-
-var build_user_agent = function()
-{
+};
+var buildUserAgent = function() {
   var str;
-  var version = "unknown";
-
+  var version = 'unknown';
   try {
     str = fs.readFileSync(__dirname + '/../package.json', 'UTF-8');
     json = JSON.parse(str);
-    version = json['version'];
+    version = json.version;
   } catch (e) {
     if (logAll) {
       util.log(e);
     }
   }
-
-  return "statsd-librato-backend/" + version;
-}
-
-var convert_string_to_regex = function (stringRegex)
-{
-    // XXX: Converting to Regexp will add another enclosing '//'
-    if (stringRegex.length > 2 && stringRegex[0] == '/' &&
-        stringRegex[stringRegex.length - 1] == '/') {
-        return new RegExp(stringRegex.slice(1, stringRegex.length - 1));
-    } else {
-        return new RegExp(stringRegex);
-    }
-}
-
-exports.init = function librato_init(startup_time, config, events, logger)
-{
+  return 'statsd-librato-backend/' + version;
+};
+var convertStringToRegex = function(stringRegex) {
+  // XXX: Converting to Regexp will add another enclosing '//'
+  if (stringRegex.length > 2 && stringRegex[0] == '/' && stringRegex[stringRegex.length - 1] == '/') {
+    return new RegExp(stringRegex.slice(1, stringRegex.length - 1));
+  } else {
+    return new RegExp(stringRegex);
+  }
+};
+exports.init = function libratoInit(startupTime, config, events, logger) {
   logAll = debug = config.debug;
-
   if (typeof logger !== 'undefined') {
-    util = logger; // override the default
+    util = logger;
+    // override the default
     logAll = true;
   }
-
   // Config options are nested under the top-level 'librato' hash
   if (config.librato) {
     api = config.librato.api;
@@ -566,112 +480,86 @@ exports.init = function librato_init(startup_time, config, events, logger)
     snapTime = config.librato.snapTime;
     includeMetrics = config.librato.includeMetrics;
     excludeMetrics = config.librato.excludeMetrics;
-
     // Handle the sourceRegex as a string
     if (typeof sourceRegex == 'string') {
-      sourceRegex = convert_string_to_regex(sourceRegex);
+      sourceRegex = convertStringToRegex(sourceRegex);
     }
-
     if (!Array.isArray(includeMetrics)) {
       includeMetrics = [];
     }
-
     for (var index = 0; index < includeMetrics.length; index++) {
       if (typeof includeMetrics[index] == 'string') {
-        includeMetrics[index] = convert_string_to_regex(includeMetrics[index]);
+        includeMetrics[index] = convertStringToRegex(includeMetrics[index]);
       }
     }
-
     if (!Array.isArray(excludeMetrics)) {
       excludeMetrics = [];
     }
-
     for (var index = 0; index < excludeMetrics.length; index++) {
       if (typeof excludeMetrics[index] == 'string') {
-        excludeMetrics[index] = convert_string_to_regex(excludeMetrics[index]);
+        excludeMetrics[index] = convertStringToRegex(excludeMetrics[index]);
       }
     }
-
     if (config.librato.countersAsGauges != null) {
       countersAsGauges = config.librato.countersAsGauges;
     }
-
     if (config.librato.skipInternalMetrics != null) {
       skipInternalMetrics = config.librato.skipInternalMetrics;
     }
-
     if (hostName == null) {
       var os = require('os');
-
       hostName = os.hostname();
     }
-
     if (config.librato.proxy && config.librato.proxy.uri) {
-
-      var tunnelFunc;
+      var TunnelFunc;
       try {
-          tunnelFunc = require('https-proxy-agent');
-      } catch(e) {
-           util.log("Cannot find module 'https-proxy-agent'.", "LOG_CRIT");
-           util.log("Make sure to run `npm install https-proxy-agent`.", "LOG_CRIT");
-           return false;
+        TunnelFunc = require('https-proxy-agent');
+      } catch (e) {
+        util.log('Cannot find module \'https-proxy-agent\'.', 'LOG_CRIT');
+        util.log('Make sure to run `npm install https-proxy-agent`.', 'LOG_CRIT');
+        return false;
       }
-
-      tunnelAgent = new tunnelFunc( config.librato.proxy.uri );
+      tunnelAgent = new TunnelFunc(config.librato.proxy.uri);
     }
-
     if (config.librato.retryDelaySecs) {
       retryDelaySecs = config.librato.retryDelaySecs;
     }
-
     if (config.librato.postTimeoutSecs) {
       postTimeoutSecs = config.librato.postTimeoutSecs;
     }
-
     if (config.librato.batchSize) {
       maxBatchSize = config.librato.batchSize;
     }
-
-    if(config.librato.alwaysSuffixPercentile) {
+    if (config.librato.alwaysSuffixPercentile) {
       alwaysSuffixPercentile = config.librato.alwaysSuffixPercentile;
     }
-
-    if(config.librato.globalPrefix) {
+    if (config.librato.globalPrefix) {
       globalPrefix = config.librato.globalPrefix + '.';
     }
-    
     // Set global measurement tags if they are defined.
     if (config.librato.tags && Object.keys(config.librato.tags).length) {
       tags = config.librato.tags;
     }
-    
     // Write metrics to legacy API
     if (config.librato.writeToLegacy) {
       writeToLegacy = config.librato.writeToLegacy;
     }
-    
     // Set host as a global tag. Defaults to os.hostname(). Can be disabled by setting host to false.
     if (hostName) {
       tags.host = hostName;
     }
   }
-
   if (!email || !token) {
-    util.log("Invalid configuration for Librato Metrics backend", "LOG_CRIT");
+    util.log('Invalid configuration for Librato Metrics backend', 'LOG_CRIT');
     return false;
   }
-
   flushInterval = config.flushInterval;
-
   if (!snapTime) {
     snapTime = Math.floor(flushInterval / 1000);
   }
-
-  userAgent = build_user_agent();
-  basicAuthHeader = build_basic_auth(email, token);
-
-  events.on('flush', flush_stats);
-  events.on('status', backend_status);
-
+  userAgent = buildUserAgent();
+  basicAuthHeader = buildBasicAuth(email, token);
+  events.on('flush', flushStats);
+  events.on('status', backendStatus);
   return true;
 };

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "extend": "^3.0.0"
   },
   "devDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-config-google": "^0.7.1",
     "nodeunit": "^0.11.0"
   },
   "main": "lib/librato.js",
   "scripts": {
-    "test": "nodeunit test"
+    "test": "yarn run eslint ./lib/librato.js && yarn run nodeunit test"
   },
   "bin": {
     "statsd-librato": "./bin/statsd-librato"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "main": "lib/librato.js",
   "scripts": {
-    "test": "yarn run nodeunit test",
-    "lint": "yarn run eslint lib test"
+    "test": "nodeunit test",
+    "lint": "eslint lib test"
   },
   "pre-commit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,18 @@
   "devDependencies": {
     "eslint": "^3.19.0",
     "eslint-config-google": "^0.7.1",
-    "nodeunit": "^0.11.0"
+    "nodeunit": "^0.11.0",
+    "pre-commit": "^1.2.2"
   },
   "main": "lib/librato.js",
   "scripts": {
-    "test": "yarn run eslint ./lib/librato.js && yarn run nodeunit test"
+    "test": "yarn run nodeunit test",
+    "lint": "yarn run eslint lib test"
   },
+  "pre-commit": [
+    "lint",
+    "test"
+  ],
   "bin": {
     "statsd-librato": "./bin/statsd-librato"
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   },
   "devDependencies": {
     "eslint": "^3.19.0",
+    "eslint-config-airbnb-base": "^11.1.3",
     "eslint-config-google": "^0.7.1",
+    "eslint-plugin-import": "^2.2.0",
     "nodeunit": "^0.11.0",
     "pre-commit": "^1.2.2"
   },

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -1,15 +1,14 @@
-var librato_init = require('../lib/librato.js').init,
-    http = require('http'),
-    events = require('events'),
-    server_port = 36001;
+var libratoInit = require('../lib/librato.js').init;
+var http = require('http');
+var events = require('events');
+var serverPort = 36001;
 
 module.exports = {
   setUp: function(callback) {
     this.server = http.createServer();
-    this.server.listen(server_port, '127.0.0.1', function() {
+    this.server.listen(serverPort, '127.0.0.1', function() {
       callback();
     });
-
     this.emitter = new events.EventEmitter();
     this.api_mock = function(validRequest, errorResponse, callback) {
       return function(req, res) {
@@ -29,122 +28,84 @@ module.exports = {
             callback(req, res, body);
           }
         });
-
       };
     };
-
     // Librato Backend
-    librato_init(null, {
+    libratoInit(null, {
       debug: false,
       librato: {
         email: '-@-',
         token: '-',
-        api: 'http://127.0.0.1:' + server_port,
-        writeToLegacy: false
-      }
+        api: 'http://127.0.0.1:' + serverPort,
+        writeToLegacy: false,
+      },
     }, this.emitter);
   },
-
-  tearDown: function (callback) {
+  tearDown: function(callback) {
     this.server.close(function() {
       callback();
     });
   },
-
   testValidMeasurementNoTags: function(test) {
     test.expect(4);
-    var metrics = {
-      gauges: {
-        my_gauge: 1
-      }
-    };
-
+    var metrics = {gauges: {my_gauge: 1}};
     this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
       var measurement = body.measurements[0];
       test.ok(measurement);
-      test.equal(measurement.name, "my_gauge");
+      test.equal(measurement.name, 'my_gauge');
       test.equal(measurement.value, 1);
       test.deepEqual(measurement.tags, {});
       test.done();
-
     }));
-
     this.emitter.emit('flush', 123, metrics);
   },
-
   testValidMeasurementSingleTag: function(test) {
     test.expect(4);
-    var metrics = {
-      gauges: {
-        "my_gauge#foo=bar": 1
-      }
-    };
-
+    var metrics = {gauges: {'my_gauge#foo=bar': 1}};
     this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
       var measurement = body.measurements[0];
       test.ok(measurement);
-      test.equal(measurement.name, "my_gauge");
+      test.equal(measurement.name, 'my_gauge');
       test.equal(measurement.value, 1);
-      test.deepEqual(measurement.tags, {foo: "bar"});
+      test.deepEqual(measurement.tags, {foo: 'bar'});
       test.done();
     }));
-
     this.emitter.emit('flush', 123, metrics);
   },
-
   testValidMeasurementMultipleTags: function(test) {
     test.expect(4);
-    var metrics = {
-      gauges: {
-        "my_gauge#foo=bar,biz=baz": 1
-      }
-    };
-
+    var metrics = {gauges: {'my_gauge#foo=bar,biz=baz': 1}};
     this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
       var measurement = body.measurements[0];
       test.ok(measurement);
-      test.equal(measurement.name, "my_gauge");
+      test.equal(measurement.name, 'my_gauge');
       test.equal(measurement.value, 1);
-      test.deepEqual(measurement.tags, {foo: "bar", biz: "baz"});
+      test.deepEqual(measurement.tags, {
+        foo: 'bar',
+        biz: 'baz',
+      });
       test.done();
     }));
-
     this.emitter.emit('flush', 123, metrics);
   },
-
   testIgnoreBrokenMetrics: function(test) {
     test.expect(5);
     var metrics = {
       gauges: {
         cool_gauge: 123,
-        bad_counter: 321
-      }
+        bad_counter: 321,
+      },
     };
-
-
-    var errors = {
-      errors: {
-        params: {
-          type: [
-            "'bad_counter'" +
-              " is a counter, but was" +
-              " submitted as different type"
-          ]
-        }
-      }
-    };
-
+    var errors = {errors: {params: {type: ['\'bad_counter\'' + ' is a counter, but was' + ' submitted as different type']}}};
     // Simulate failure...
     this.server.once('request', this.api_mock(false, errors, function(req, res, body) {
       var gauges = {};
       for (var k in body.measurements) {
         gauges[body.measurements[k].name] = body.measurements[k].value;
       }
-
       test.ok(gauges.cool_gauge);
       test.ok(gauges.bad_counter);
       test.equal(res.statusCode, 400);
-
       setTimeout(function() {
         this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
           var gauges = {};
@@ -158,34 +119,30 @@ module.exports = {
         this.emitter.emit('flush', 123, metrics);
       }.bind(this), 500);
     }.bind(this)));
-
     this.emitter.emit('flush', 123, metrics);
-
   },
-
   testTimers: function(test) {
     test.expect(7);
     var metrics = {
       timers: {
-        "my_timer#tag=foo": [41, 73.5]
+        'my_timer#tag=foo': [
+          41,
+          73.5,
+        ],
       },
-      timer_data: {
-        "my_timer#tag=foo": null
-      }
+      timer_data: {'my_timer#tag=foo': null},
     };
-
     this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
       var measurement = body.measurements[0];
       test.ok(measurement);
-      test.equal(measurement.name, "my_timer");
+      test.equal(measurement.name, 'my_timer');
       test.equal(measurement.value, undefined);
       test.equal(measurement.min, 41);
       test.equal(measurement.max, 73.5);
       test.equal(measurement.sum, 114.5);
-      test.deepEqual(measurement.tags, {tag: "foo"});
+      test.deepEqual(measurement.tags, {tag: 'foo'});
       test.done();
     }));
-
     this.emitter.emit('flush', 123, metrics);
-  }
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,31 @@
 # yarn lockfile v1
 
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
+acorn@^5.0.1:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
+
+ajv-keywords@^1.0.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+
+ajv@^4.7.0:
+  version "4.11.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.5.tgz#b6ee74657b993a01dce44b7944d56f485828d5bd"
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -13,6 +38,10 @@ align-text@^0.1.1, align-text@^0.1.3:
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+
+ansi-escapes@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -48,11 +77,21 @@ arr-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
 
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
-arrify@^1.0.1:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -84,7 +123,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -210,6 +249,16 @@ caching-transform@^1.0.0:
     mkdirp "^0.5.1"
     write-file-atomic "^1.1.4"
 
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -229,7 +278,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.1.0, chalk@^1.1.1:
+chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -239,9 +288,23 @@ chalk@^1.1.0, chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+circular-json@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
+
 clean-yaml-object@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz#63fb110dc2ce1a84dc21f6d9334876d010ae8b68"
+
+cli-cursor@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  dependencies:
+    restore-cursor "^1.0.1"
+
+cli-width@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -258,6 +321,10 @@ cliui@^3.2.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
+
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -286,6 +353,14 @@ commondir@^1.0.1:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+concat-stream@^1.5.2:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
 
 convert-source-map@^1.3.0:
   version "1.5.0"
@@ -322,6 +397,12 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -332,7 +413,7 @@ debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@^2.1.3, debug@^2.2.0:
+debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
@@ -341,6 +422,10 @@ debug@^2.1.3, debug@^2.2.0:
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
 deeper@^2.1.0:
   version "2.1.0"
@@ -351,6 +436,18 @@ default-require-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
   dependencies:
     strip-bom "^2.0.0"
+
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -365,6 +462,13 @@ detect-indent@^4.0.0:
 diff@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+
+doctrine@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -382,9 +486,117 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3:
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.15"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.15.tgz#c330a5934c1ee21284a7c081a86e5fd937c91ea6"
+  dependencies:
+    es6-iterator "2"
+    es6-symbol "~3.1"
+
+es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-symbol "^3.1"
+
+es6-map@^0.1.3:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
+
+es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
+
+es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+es6-weak-map@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
+
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+escope@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+  dependencies:
+    es6-map "^0.1.3"
+    es6-weak-map "^2.0.1"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+  dependencies:
+    babel-code-frame "^6.16.0"
+    chalk "^1.1.3"
+    concat-stream "^1.5.2"
+    debug "^2.1.1"
+    doctrine "^2.0.0"
+    escope "^3.6.0"
+    espree "^3.4.0"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~2.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
+espree@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.1.tgz#28a83ab4aaed71ed8fe0f5efe61b76a05c13c4d2"
+  dependencies:
+    acorn "^5.0.1"
+    acorn-jsx "^3.0.0"
 
 esprima@^2.6.0:
   version "2.7.3"
@@ -394,13 +606,45 @@ esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.1.0.tgz#4713b6536adf7f2ac4f327d559e7756bff648220"
+  dependencies:
+    estraverse "~4.1.0"
+    object-assign "^4.0.1"
+
+estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+
+estraverse@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+event-emitter@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
 events-to-array@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.0.2.tgz#b3484465534fe4ff66fbdd1a83b777713ba404aa"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -427,6 +671,24 @@ extglob@^0.3.1:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+figures@^1.3.5:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -456,6 +718,15 @@ find-up@^1.0.0, find-up@^1.1.2:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
+
+flat-cache@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.2.tgz#fa86714e72c21db88601761ecf2f555d1abc6b96"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -531,7 +802,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.5, glob@^7.0.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -542,9 +813,20 @@ glob@^7.0.0, glob@^7.0.5, glob@^7.0.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0:
+globals@^9.0.0, globals@^9.14.0:
   version "9.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
@@ -608,6 +890,10 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+ignore@^3.2.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.7.tgz#4810ca5f1d8eca5595213a34b94f2eb4ed926bbd"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -619,9 +905,31 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.1:
+inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inquirer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    ansi-regex "^2.0.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^2.0.0"
+    figures "^1.3.5"
+    lodash "^4.3.0"
+    readline2 "^1.0.1"
+    run-async "^0.1.0"
+    rx-lite "^3.1.2"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
+
+interpret@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.2.tgz#f4f623f0bb7122f15f5717c8e254b8161b5c5b2d"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -677,13 +985,17 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
 
-is-my-json-valid@^2.12.4:
+is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
   dependencies:
@@ -698,6 +1010,22 @@ is-number@^2.0.2, is-number@^2.1.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz#6477582b8214d602346094567003be8a9eac04dc"
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -710,6 +1038,12 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
+is-resolvable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
+  dependencies:
+    tryit "^1.0.1"
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -718,7 +1052,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -803,7 +1137,7 @@ js-yaml@3.6.1:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.2.7, js-yaml@^3.3.1:
+js-yaml@^3.2.7, js-yaml@^3.3.1, js-yaml@^3.5.1:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766"
   dependencies:
@@ -822,9 +1156,19 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
+json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
 jsonpointer@^4.0.0:
   version "4.0.1"
@@ -859,6 +1203,13 @@ lcov-parse@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -869,7 +1220,7 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-lodash@^4.2.0:
+lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -962,6 +1313,14 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+mute-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
 nodeunit@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/nodeunit/-/nodeunit-0.11.0.tgz#5f57579e2a7f3286fd04937bfd5665070c4e015c"
@@ -1024,7 +1383,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1041,6 +1400,10 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
 only-shallow@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/only-shallow/-/only-shallow-1.2.0.tgz#71cecedba9324bc0518aef10ec080d3249dc2465"
@@ -1056,7 +1419,18 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-os-homedir@1.0.1, os-homedir@^1.0.1:
+optionator@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
+
+os-homedir@1.0.1, os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.1.tgz#0d62bdf44b916fd3bbdcf2cab191948fb094f007"
 
@@ -1099,6 +1473,10 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-is-inside@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
@@ -1131,6 +1509,14 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+pluralize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -1138,6 +1524,10 @@ preserve@^0.2.0:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+progress@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
 pseudomap@^1.0.1:
   version "1.0.2"
@@ -1173,7 +1563,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2, readable-stream@^2.0.2, readable-stream@^2.1.5:
+readable-stream@^2, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.8.tgz#ad28b686f3554c73d39bc32347fa058356624705"
   dependencies:
@@ -1184,6 +1574,20 @@ readable-stream@^2, readable-stream@^2.0.2, readable-stream@^2.1.5:
     process-nextick-args "~1.0.6"
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
+
+readline2@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    mute-stream "0.0.5"
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
 
 regenerator-runtime@^0.10.0:
   version "0.10.3"
@@ -1247,9 +1651,33 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-uncached@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+
+resolve@^1.1.6:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
+  dependencies:
+    path-parse "^1.0.5"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -1257,11 +1685,21 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.3.3, rimraf@^2.4.4, rimraf@^2.5.4:
+rimraf@^2.2.8, rimraf@^2.3.3, rimraf@^2.4.4, rimraf@^2.5.4:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
+
+run-async@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+  dependencies:
+    once "^1.3.0"
+
+rx-lite@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.3.0"
@@ -1271,6 +1709,14 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+shelljs@^0.7.5:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 signal-exit@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-2.1.2.tgz#375879b1f92ebc3b334480d038dc546a6d558564"
@@ -1278,6 +1724,10 @@ signal-exit@^2.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 slide@^1.1.5:
   version "1.1.6"
@@ -1361,6 +1811,13 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^3.0.0"
+
 string_decoder@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
@@ -1383,6 +1840,14 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -1392,6 +1857,17 @@ supports-color@^3.1.2:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+table@^3.7.8:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+  dependencies:
+    ajv "^4.7.0"
+    ajv-keywords "^1.0.0"
+    chalk "^1.1.1"
+    lodash "^4.0.0"
+    slice-ansi "0.0.4"
+    string-width "^2.0.0"
 
 tap-mocha-reporter@^3.0.1:
   version "3.0.3"
@@ -1459,6 +1935,14 @@ test-exclude@^4.0.0:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-table@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
 tmatch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/tmatch/-/tmatch-3.0.0.tgz#7d2071dedbbc587f194acda3067bd0747b670991"
@@ -1481,6 +1965,10 @@ trivial-deferred@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trivial-deferred/-/trivial-deferred-1.0.1.tgz#376d4d29d951d6368a6f7a0ae85c2f4d5e0658f3"
 
+tryit@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
+
 tunnel-agent@~0.4.1:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
@@ -1488,6 +1976,16 @@ tunnel-agent@~0.4.1:
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  dependencies:
+    prelude-ls "~1.1.2"
+
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 uglify-js@^2.6:
   version "2.8.21"
@@ -1508,6 +2006,12 @@ unicode-length@^1.0.0:
   dependencies:
     punycode "^1.3.2"
     strip-ansi "^3.0.1"
+
+user-home@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
+  dependencies:
+    os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -1552,6 +2056,10 @@ wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -1570,6 +2078,12 @@ write-file-atomic@^1.1.4:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     slide "^1.1.5"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 xtend@^4.0.0:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,7 +354,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.2:
+concat-stream@^1.4.7, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -389,6 +389,14 @@ cross-spawn@^4:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -550,6 +558,10 @@ escope@^3.6.0:
     es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-config-google@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.7.1.tgz#5598f8498e9e078420f34b80495b8d959f651fb2"
 
 eslint@^3.19.0:
   version "3.19.0"
@@ -1440,6 +1452,10 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
+os-shim@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
+
 own-or-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/own-or-env/-/own-or-env-1.0.0.tgz#9ef920fc81e2e63cf59d41101258368cf4fca4fb"
@@ -1512,6 +1528,14 @@ pkg-dir@^1.0.0:
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
+pre-commit@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
+  dependencies:
+    cross-spawn "^5.0.1"
+    spawn-sync "^1.0.15"
+    which "1.2.x"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -1709,6 +1733,16 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 shelljs@^0.7.5:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
@@ -1754,6 +1788,13 @@ source-map@^0.4.4:
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+spawn-sync@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
+  dependencies:
+    concat-stream "^1.4.7"
+    os-shim "^0.1.2"
 
 spawn-wrap@1.2.4:
   version "1.2.4"
@@ -2038,7 +2079,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.2.4, which@^1.2.9:
+which@1.2.x, which@^1.2.4, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:


### PR DESCRIPTION
This PR adds eslint support. The following major changes have been made:

- [x] `librato.js` and `librato_test.js` have been linted and fixed up
- [x] Initial `.eslintrc.json` has been added but is not necessarily set in stone
- [x] A `pre-commit` hook has been added that runs lint and CI tests. 

Unfortunately there is a bit of churn with `librato.js` due to the numerous lint failers (300+ iirc)