### PR TITLE
Fix issue when data > maxBatchSize wouldn't send

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -280,8 +280,8 @@ var flushStats = function libratoFlush(ts, metrics) {
     // Add the payload
     measurements.push(measure);
     // Post measurements and clear arrays if past batch size
-    if (measurements >= maxBatchSize || writeToLegacy && counters.length + gauges.length >= maxBatchSize) {
-      post_metrics(measureTime, gauges, counters, measurements);
+    if (measurements.length >= maxBatchSize || writeToLegacy && counters.length + gauges.length >= maxBatchSize) {
+      postMetrics(measureTime, gauges, counters, measurements);
       if (measurements >= maxBatchSize) {
         measurements = [];
       }

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -38,6 +38,7 @@ module.exports = {
         token: '-',
         api: 'http://127.0.0.1:' + serverPort,
         writeToLegacy: false,
+        batchSize: 5,
       },
     }, this.emitter);
   },
@@ -144,5 +145,21 @@ module.exports = {
       test.done();
     }));
     this.emitter.emit('flush', 123, metrics);
+  },
+
+  testMaxBatchSize: function(test) {
+    test.expect(0);
+    var gauges = {};
+    for (var i = 0; i < 5; i++) {
+      var key = 'gauge' + i;
+      gauges[key] = 1;
+    }
+    var metrics = {gauges: gauges};
+
+    this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
+    }));
+
+    this.emitter.emit('flush', 123, metrics);
+    test.done();
   },
 };


### PR DESCRIPTION
Looks like my linter broke the method name but, even before linting, this wasn't happening due to a lack of a `.length` call.