### PR TITLE
Port tests to ES6. Use nock and sinon for better mocking / stubbing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js: 
   - "stable"
   - "6"
-  - "5"
   - "4"
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
   - "6"
   - "5"
   - "4"
-  - "0.12"
-  - "0.10"
 matrix:
   fast_finish: true
 before_script:

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "eslint-config-airbnb-base": "^11.1.3",
     "eslint-config-google": "^0.7.1",
     "eslint-plugin-import": "^2.2.0",
+    "nock": "^9.0.13",
     "nodeunit": "^0.11.0",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "sinon": "^2.1.0"
   },
   "main": "lib/librato.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "main": "lib/librato.js",
   "scripts": {
-    "test": "nodeunit test",
+    "test": "nodeunit",
     "lint": "eslint lib test"
   },
   "pre-commit": [

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const http = require('http');
 const events = require('events');
 const serverPort = 36001;

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const http = require('http');
 const events = require('events');
 const serverPort = 36001;

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -1,9 +1,11 @@
+'use strict';
+
 const http = require('http');
 const events = require('events');
 const serverPort = 36001;
 const librato = require('../lib/librato.js');
 
-let emitter;
+var emitter;
 
 module.exports = {
   setUp: function(callback) {
@@ -33,8 +35,8 @@ module.exports = {
         });
       };
     };
-    // Librato Backend
-    librato.init(null, {
+
+    this.config = {
       debug: false,
       librato: {
         email: '-@-',
@@ -43,13 +45,17 @@ module.exports = {
         writeToLegacy: false,
         batchSize: 5,
       },
-    }, emitter);
+    };
+
+    librato.init(null, this.config, emitter);
   },
+
   tearDown: function(callback) {
     this.server.close(function() {
       callback();
     });
   },
+
   testValidMeasurementNoTags: function(test) {
     let metrics = {gauges: {my_gauge: 1}};
 
@@ -77,6 +83,7 @@ module.exports = {
     }));
     emitter.emit('flush', 123, metrics);
   },
+
   testValidMeasurementMultipleTags: function(test) {
     test.expect(4);
     let metrics = {gauges: {'my_gauge#foo=bar,biz=baz': 1}};
@@ -93,6 +100,7 @@ module.exports = {
     }));
     emitter.emit('flush', 123, metrics);
   },
+
   testIgnoreBrokenMetrics: function(test) {
     test.expect(5);
     let metrics = {
@@ -126,6 +134,7 @@ module.exports = {
     }.bind(this)));
     emitter.emit('flush', 123, metrics);
   },
+
   testTimers: function(test) {
     test.expect(7);
     let metrics = {

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -21,7 +21,6 @@ module.exports = {
         token: '-',
         api: 'http://127.0.0.1:' + serverPort,
         writeToLegacy: false,
-        batchSize: 5,
       },
     };
 
@@ -132,14 +131,20 @@ module.exports = {
   },
 
   testMaxBatchSize: function(test) {
-    test.expect(0);
+    test.expect(2);
     var gauges = {};
-    for (var i = 0; i < 5; i++) {
+    for (var i = 0; i < 500; i++) {
       var key = 'gauge' + i;
       gauges[key] = 1;
     }
     var metrics = {gauges: gauges};
+    this.apiServer.post('/v1/measurements')
+                  .reply(200, function(uri, requestBody) {
+                    test.ok(requestBody.measurements);
+                    test.equal(requestBody.measurements.length, 500);
+                    test.done();
+                  });
 
-    test.done();
+    emitter.emit('flush', 123, metrics);
   },
 };

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -130,8 +130,8 @@ module.exports = {
                  let measurements = requestBody.measurements;
                  let gaugeNames = measurements.map((gauge) => gauge.name);
                  test.equal(requestBody.measurements.length, 1);
-                 test.ok(gaugeNames.includes('cool_gauge'));
-                 test.ok(!gaugeNames.includes('bad_counter'));
+                 test.equal(gaugeNames.indexOf('cool_gauge'), 0);
+                 test.equal(gaugeNames.indexOf('bad_counter'), -1);
                  test.done();
                });
 

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -1,40 +1,18 @@
 'use strict';
 
-const http = require('http');
 const events = require('events');
 const serverPort = 36001;
 const librato = require('../lib/librato.js');
+const nock = require('nock');
 
 var emitter;
 
 module.exports = {
   setUp: function(callback) {
     emitter = new events.EventEmitter();
-    this.server = http.createServer();
-    this.server.listen(serverPort, '127.0.0.1', function() {
-      callback();
-    });
 
-    this.api_mock = function(validRequest, errorResponse, callback) {
-      return function(req, res) {
-        let data = '';
-        req.on('data', function(chunk) {
-          data += chunk;
-        });
-        req.on('end', function() {
-          let body = JSON.parse(data);
-          if (validRequest) {
-            res.writeHead(200, {});
-            res.end('');
-            callback(req, res, body);
-          } else {
-            res.writeHead(400, {'content-type': 'application/json'});
-            res.end(JSON.stringify(errorResponse));
-            callback(req, res, body);
-          }
-        });
-      };
-    };
+    this.apiServer = nock('http://127.0.0.1:36001')
+                         .defaultReplyHeaders({'Content-Type': 'application/json'});
 
     this.config = {
       debug: false,
@@ -48,90 +26,61 @@ module.exports = {
     };
 
     librato.init(null, this.config, emitter);
+    callback();
   },
 
   tearDown: function(callback) {
-    this.server.close(function() {
-      callback();
-    });
+    callback();
   },
 
   testValidMeasurementNoTags: function(test) {
+    test.expect(4);
     let metrics = {gauges: {my_gauge: 1}};
+    this.apiServer.post('/v1/measurements')
+             .reply(200, function(uri, requestBody) {
+                let measurement = requestBody.measurements[0];
+                test.ok(requestBody);
+                test.equal(measurement.name, 'my_gauge');
+                test.equal(measurement.value, 1);
+                test.deepEqual(measurement.tags, {});
+                test.done();
+             });
 
-    this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
-      let measurement = body.measurements[0];
-      test.ok(measurement);
-      test.equal(measurement.name, 'my_gauge');
-      test.equal(measurement.value, 1);
-      test.deepEqual(measurement.tags, {});
-      test.done();
-    }));
     emitter.emit('flush', 123, metrics);
   },
 
   testValidMeasurementSingleTag: function(test) {
     test.expect(4);
     let metrics = {gauges: {'my_gauge#foo=bar': 1}};
-    this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
-      let measurement = body.measurements[0];
-      test.ok(measurement);
-      test.equal(measurement.name, 'my_gauge');
-      test.equal(measurement.value, 1);
-      test.deepEqual(measurement.tags, {foo: 'bar'});
-      test.done();
-    }));
+    this.apiServer.post('/v1/measurements')
+             .reply(200, function(uri, requestBody) {
+                let measurement = requestBody.measurements[0];
+                test.ok(requestBody);
+                test.equal(measurement.name, 'my_gauge');
+                test.equal(measurement.value, 1);
+                test.deepEqual(measurement.tags, {foo: 'bar'});
+                test.done();
+             });
+
     emitter.emit('flush', 123, metrics);
   },
 
   testValidMeasurementMultipleTags: function(test) {
     test.expect(4);
     let metrics = {gauges: {'my_gauge#foo=bar,biz=baz': 1}};
-    this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
-      let measurement = body.measurements[0];
-      test.ok(measurement);
-      test.equal(measurement.name, 'my_gauge');
-      test.equal(measurement.value, 1);
-      test.deepEqual(measurement.tags, {
-        foo: 'bar',
-        biz: 'baz',
-      });
-      test.done();
-    }));
-    emitter.emit('flush', 123, metrics);
-  },
+    this.apiServer.post('/v1/measurements')
+             .reply(200, function(uri, requestBody) {
+                let measurement = requestBody.measurements[0];
+                test.ok(requestBody);
+                test.equal(measurement.name, 'my_gauge');
+                test.equal(measurement.value, 1);
+                test.deepEqual(measurement.tags, {
+                  foo: 'bar',
+                  biz: 'baz',
+                });
+                test.done();
+             });
 
-  testIgnoreBrokenMetrics: function(test) {
-    test.expect(5);
-    let metrics = {
-      gauges: {
-        cool_gauge: 123,
-        bad_counter: 321,
-      },
-    };
-    let errors = {errors: {params: {type: ['\'bad_counter\'' + ' is a counter, but was' + ' submitted as different type']}}};
-    // Simulate failure...
-    this.server.once('request', this.api_mock(false, errors, function(req, res, body) {
-      let gauges = {};
-      for (let k in body.measurements) {
-        gauges[body.measurements[k].name] = body.measurements[k].value;
-      }
-      test.ok(gauges.cool_gauge);
-      test.ok(gauges.bad_counter);
-      test.equal(res.statusCode, 400);
-      setTimeout(function() {
-        this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
-          let gauges = {};
-          for (let k in body.measurements) {
-            gauges[body.measurements[k].name] = body.measurements[k].value;
-          }
-          test.ok(gauges.cool_gauge);
-          test.strictEqual(gauges.bad_counter, undefined);
-          test.done();
-        }));
-        emitter.emit('flush', 123, metrics);
-      }.bind(this), 500);
-    }.bind(this)));
     emitter.emit('flush', 123, metrics);
   },
 
@@ -146,17 +95,39 @@ module.exports = {
       },
       timer_data: {'my_timer#tag=foo': null},
     };
-    this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
-      let measurement = body.measurements[0];
-      test.ok(measurement);
-      test.equal(measurement.name, 'my_timer');
-      test.equal(measurement.value, undefined);
-      test.equal(measurement.min, 41);
-      test.equal(measurement.max, 73.5);
-      test.equal(measurement.sum, 114.5);
-      test.deepEqual(measurement.tags, {tag: 'foo'});
-      test.done();
-    }));
+    this.apiServer.post('/v1/measurements')
+             .reply(200, function(uri, requestBody) {
+                let measurement = requestBody.measurements[0];
+                test.ok(measurement);
+                test.equal(measurement.name, 'my_timer');
+                test.equal(measurement.value, undefined);
+                test.equal(measurement.min, 41);
+                test.equal(measurement.max, 73.5);
+                test.equal(measurement.sum, 114.5);
+                test.deepEqual(measurement.tags, {tag: 'foo'});
+                test.done();
+             });
+
+    emitter.emit('flush', 123, metrics);
+  },
+
+  testIgnoreBrokenMetrics: function(test) {
+    test.expect(0);
+    let metrics = {
+      gauges: {
+        cool_gauge: 123,
+        bad_counter: 321,
+      },
+    };
+    let errors = {errors: {params: {type: ['\'bad_counter\'' + ' is a counter, but was' + ' submitted as different type']}}};
+
+    this.apiServer.post('/v1/measurements')
+                  .replyWithError(errors)
+                  .post('/v1/measurements')
+                  .reply(200, function(uri, requestBody) {
+                    test.done();
+                  });
+
     emitter.emit('flush', 123, metrics);
   },
 
@@ -169,10 +140,6 @@ module.exports = {
     }
     var metrics = {gauges: gauges};
 
-    this.server.once('request', this.api_mock(true, {}, function(req, res, body) {
-    }));
-
-    this.emitter.emit('flush', 123, metrics);
     test.done();
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,7 +237,7 @@ buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -362,6 +362,10 @@ concat-stream@^1.4.7, concat-stream@^1.5.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+
 convert-source-map@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
@@ -421,6 +425,12 @@ debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
+debug@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+  dependencies:
+    ms "0.7.1"
+
 debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
@@ -470,6 +480,13 @@ detect-indent@^4.0.0:
 diff@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
 
 doctrine@^2.0.0:
   version "2.0.0"
@@ -559,9 +576,43 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-config-airbnb-base@^11.1.3:
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.1.3.tgz#0e8db71514fa36b977fbcf977c01edcf863e0cf0"
+
 eslint-config-google@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.7.1.tgz#5598f8498e9e078420f34b80495b8d959f651fb2"
+
+eslint-import-resolver-node@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
+  dependencies:
+    debug "^2.2.0"
+    object-assign "^4.0.1"
+    resolve "^1.1.6"
+
+eslint-module-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
+  dependencies:
+    debug "2.2.0"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.2.0"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.2.0"
+    eslint-module-utils "^2.0.0"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    pkg-up "^1.0.0"
 
 eslint@^3.19.0:
   version "3.19.0"
@@ -777,6 +828,10 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+function-bind@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
+
 function-loop@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/function-loop/-/function-loop-1.0.1.tgz#8076bb305e8e6a3cceee2920765f330d190f340c"
@@ -876,6 +931,12 @@ has-ansi@^2.0.0:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+has@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -1232,6 +1293,10 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
 lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -1301,7 +1366,7 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.27.0"
 
-minimatch@^3.0.2:
+minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -1320,6 +1385,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+ms@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
 ms@0.7.2:
   version "0.7.2"
@@ -1522,6 +1591,12 @@ pinkie@^2.0.0:
 pkg-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
+pkg-up@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
   dependencies:
     find-up "^1.0.0"
 
@@ -1894,8 +1969,8 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 supports-color@^3.1.2:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
     has-flag "^1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,6 +107,10 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+assertion-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
+
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -278,6 +282,14 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+"chai@>=1.9.2 <4.0.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
+  dependencies:
+    assertion-error "^1.0.1"
+    deep-eql "^0.1.3"
+    type-detect "^1.0.0"
+
 chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -441,6 +453,16 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-eql@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
+  dependencies:
+    type-detect "0.1.1"
+
+deep-equal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -480,6 +502,10 @@ detect-indent@^4.0.0:
 diff@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+
+diff@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -820,6 +846,12 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
+
 fs-exists-cached@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz#cf25554ca050dc49ae6656b41de42258989dcbce"
@@ -1125,6 +1157,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1235,7 +1271,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -1297,13 +1333,17 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
+
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -1398,9 +1438,26 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nock@^9.0.13:
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.0.13.tgz#d0bc39ef43d3179981e22b2e8ea069f916c5781a"
+  dependencies:
+    chai ">=1.9.2 <4.0.0"
+    debug "^2.2.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "~4.17.2"
+    mkdirp "^0.5.0"
+    propagate "0.4.0"
+    qs "^6.0.2"
 
 nodeunit@^0.11.0:
   version "0.11.0"
@@ -1566,6 +1623,12 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -1628,6 +1691,10 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+propagate@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
+
 pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -1636,7 +1703,7 @@ punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-qs@~6.3.0:
+qs@^6.0.2, qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
 
@@ -1800,6 +1867,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -1833,6 +1904,19 @@ signal-exit@^2.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.1.0.tgz#e057a9d2bf1b32f5d6dd62628ca9ee3961b0cafb"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -2051,6 +2135,10 @@ test-exclude@^4.0.0:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2098,6 +2186,18 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
+
+type-detect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.0.tgz#62053883542a321f2f7b25746dc696478b18ff6b"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
This PR is providing some updates to our test suite. Big changes:

- [x] ES6 syntax where appropriate since we support Node 4
- [x] Ditch in-house `api_mock` in favor of mocks with `nock`. This allows us to simulate failures on a per test level and really customize how the Librato would respond
- [x] Add `sinon` as a dep for stubs and spies and mocks
- [x] Remove EOL node versions from the build matrix. Only test against `stable` and the LTS versions

Hopefully, over time, we can make our test suite stronger and prevent small bugs from slipping through the cracks (such as https://github.com/librato/statsd-librato-backend/pull/79)