### PR TITLE
parse metric name and tags with histograms support

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -294,23 +294,34 @@ var flushStats = function libratoFlush(ts, metrics) {
   var parseAndSetTags = function(measureName, measure) {
     // Valid format for parsing tags out: global-prefix.name#tag1=value,tag2=value
     // NOTE: Name can include the source
+    // Histogram bins: global-prefix.name#tag1=val1,tag2=val2.bin_50 => name: global-prefix.name.bin_50
+
+    var metricName = '';
+
     var vals = measureName.split('#');
-    if (vals.length > 1) {
-      // Found tags in the measureName. Parse them out and return the measureName without the tags.
-      measureName = vals.shift();
-      rawTags = vals.pop().split(',');
-      rawTags.forEach(function(rawTag) {
-        var name = rawTag.split('=').shift();
-        var value = rawTag.split('=').pop();
-        if (name.length && value.length) {
-          measure.tags[name] = value;
-        }
-      });
-      return measureName;
-    } else {
-      // No tags existed in the measureName
+    if ( vals.length < 2 ) {
       return measureName;
     }
+
+    // Found tags in the measureName. Parse them out and return the measureName without the tags.
+    metricName = vals.shift();
+    var tags = vals[0];
+
+    var pos = tags.lastIndexOf('.bin_');
+    if (pos > -1) {
+      metricName += tags.substr(pos);
+      tags = tags.substr(0, pos);
+    }
+
+    rawTags = tags.split(',');
+    rawTags.forEach( function(rawTag) {
+      var name = rawTag.split('=').shift();
+      var value = rawTag.split('=').pop();
+      if (name.length && value.length) {
+        measure.tags[name] = value;
+      }
+    } );
+    return metricName;
   };
   for (key in metrics.counters) {
     if (skipInternalMetrics && key.match(internalStatsdRe) != null) {

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -478,6 +478,8 @@ exports.init = function libratoInit(startupTime, config, events, logger) {
   if (typeof logger !== 'undefined') {
     util = logger;
     // override the default
+    // disabled by mugurax: when I say debug:false, means debug false.
+    // probably smthg wrong in my config, nevertheles, until I find the route cause...
     logAll = true;
   }
   // Config options are nested under the top-level 'librato' hash

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -480,7 +480,7 @@ exports.init = function libratoInit(startupTime, config, events, logger) {
     // override the default
     // disabled by mugurax: when I say debug:false, means debug false.
     // probably smthg wrong in my config, nevertheles, until I find the route cause...
-    logAll = true;
+    /* logAll = true; */
   }
   // Config options are nested under the top-level 'librato' hash
   if (config.librato) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-
   "author": "Mike Heffner <mike@librato.com>",
   "name": "statsd-librato-backend",
   "description": "A StatsD backend for Librato Metrics",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+
   "author": "Mike Heffner <mike@librato.com>",
   "name": "statsd-librato-backend",
   "description": "A StatsD backend for Librato Metrics",

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -62,6 +62,22 @@ module.exports = {
     this.emitter.emit('flush', 123, metrics);
   },
 
+  testValidMeasurementSingleTagFromHistogram: function(test) {
+    test.expect(4);
+    let metrics = {gauges: {'my_gauge#foo=bar.bin_50': 1}};
+    this.apiServer.post('/v1/measurements')
+             .reply(200, (uri, requestBody) => {
+                let measurement = requestBody.measurements[0];
+                test.ok(requestBody);
+                test.equal(measurement.name, 'my_gauge.bin_50');
+                test.equal(measurement.value, 1);
+                test.deepEqual(measurement.tags, {foo: 'bar'});
+                test.done();
+             });
+
+    this.emitter.emit('flush', 123, metrics);
+  },
+
   testValidMeasurementMultipleTags: function(test) {
     test.expect(4);
     let metrics = {gauges: {'my_gauge#foo=bar,biz=baz': 1}};


### PR DESCRIPTION
When sending timers with histograms, statsd creates new gauges with .bin_x added to the original metric name.

For instance: global-prefix.name#tag=val is sent to statsd-librato-backend as global-prefix.name#tag=val.bin_50

This format is not supported by the existing parseAndSetTags.

Thanks,
Mugur