### PR TITLE
Append the `globalPrefix` only after `sourceRegex` alterations to the mea…

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -241,24 +241,26 @@ var flushStats = function libratoFlush(ts, metrics) {
   var addMeasure = function addMeasure(mType, measure, countStat) {
     countStat = typeof countStat !== 'undefined' ? countStat : true;
     var match;
-    var measureName = globalPrefix + measure.name;
+    var measureName = measure.name;
     measure.tags = {};
     measureName = parseAndSetTags(measureName, measure);
     // Use first capturing group as source name.
     // NOTE: Only legacy users will a) have a source and b) have a source set by regex
     if (sourceRegex && (match = measureName.match(sourceRegex)) && match[1]) {
       measure.source = sanitizeName(match[1]);
-      // Remove entire matching string from the measure name & add global prefix.
-      measure.name = sanitizeName(measureName.slice(0, match.index) + measureName.slice(match.index + match[0].length));
+      // Remove entire matching string from the measure name, add global prefix and sanitize the final measure name.
+      measure.name = sanitizeName(globalPrefix + measureName.slice(0, match.index) + measureName.slice(match.index + match[0].length));
       // Create a measurement-level tag named source
       measure.tags.source = measure.source;
     } else {
-      measure.name = sanitizeName(measureName);
+      // add global prefix and sanitize the final measure name.
+      measure.name = sanitizeName(globalPrefix + measureName);
       // Use the global config sourceName as a source tag, if it exists.
       if (sourceName !== null) {
         measure.tags.source = sourceName;
       }
     }
+
     if (brokenMetrics[measure.name]) {
       return;
     }


### PR DESCRIPTION
…sureName have been done, or if there is no `sourceRegex` configured.

Unlike in version 1.7.x, the `globalPrefix` is being applied to the metric name before it is run through the `sourceRegex` to pull out the `source` and discard the matching substring from the metric name. So instead of the `sourceRegex` being matched against the original statsd metric name, it's being matched against the metric name with the prefix added on the beginning, which causes unexpected results.

I've changed it so that the `globalPrefix` is applied at the same point the `sanitizeName` function is applied. I.e., those are the last things that happen to the metric name before it is set on the `measure` object.