### PR TITLE
Exclude the source property from measurements sent to /measurements, …

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -277,6 +277,8 @@ var flushStats = function libratoFlush(ts, metrics) {
         gauges.push(legacyMeasure);
       }
     }
+
+    delete measure.source;
     // Add the payload
     measurements.push(measure);
     // Post measurements and clear arrays if past batch size

--- a/test/librato_tests.js
+++ b/test/librato_tests.js
@@ -386,12 +386,14 @@ module.exports.legacy = {
     config.librato.sourceRegex = /^(.*?)--/;
     librato.init(null, config, this.emitter);
 
-    test.expect(8);
+    test.expect(9);
     let metrics = {gauges: {'rails-application--my_gauge': 1}};
     this.apiServer.post('/v1/measurements')
                   .reply(200, (uri, requestBody) => {
                     let measurement = requestBody.measurements[0];
                     test.ok(requestBody);
+                    // no source when using the measurements api
+                    test.equal(measurement.source, undefined);
                     test.equal(measurement.name, 'my_gauge');
                     test.equal(measurement.value, 1);
                     test.deepEqual(measurement.tags, {source: 'rails-application'});


### PR DESCRIPTION
…as it it invalid to include in the posted request.

Measurements are constructed with a `source` property, but the API definition doesn't have that property in the `POST` request body to `/v1/measurements` (https://www.librato.com/docs/api/#measurements). If that property is there, a `400 Bad Request` is returned from the API, with the following detail `{"code":400,"message":"Unable to process JSON"}`.

In the PR, the `source` is deleted off the measurement prior to being added to the collection. I left it as a property because the `legacyMeasure` expects that property to be there in order to create itself through `extend`.