### PR TITLE
Adding in an option to include top level tags in metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,5 +226,9 @@ To run the test just use the following command:
 
         nodeunit tests/librato_tests.js
 
+If you have [yarn](https://yarnpkg.com/en/) installed you can run your unit tests with:
+        
+        yarn test
+
 [statsd]: https://github.com/etsy/statsd
 [tags]: #tags

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ options under the top-level `librato` hash:
 | excludeMetrics | An array of JavaScript regular expressions. Metrics which match any of the regular expressions will NOT be sent to Librato. If includedMetrics is specified, then patterns will be matched against the resulting list of included metrics. Defaults to an empty array.<br/><br/>{excludeMetrics: [/^my\.excluded\.metrics/, /^my.specifically.excluded.metric$/]} |
 | globalPrefix | A string to prepend to all measurement names sent to Librato. If set, a dot will automatically be added as separator between prefix and measurement name. |
 | writeToLegacy | Boolean of whether to also send metrics with the legacy `source` dimension. Defaults to `false`. Intended for users with hybrid accounts that support both tags and sources to help with the migration to tags. Set the source in the StatsD config file:<br/><br/>librato: {<br/>email:  "myemail@example.com",<br/>token:  "ca98e2bc23b1bfd0cbe9041e82d52ca4ac22cf3eab5a1c32",<br/>source: "unique-per-statsd-instance"<br/>    } |
+| alwaysIncludeTopLevelTags | Boolean of whether to add the top level [tags] specified in the config. Defaults to `false`. Intended for users with accounts that support tags. This will first set tags on measurements from the topLevel [tags] and then overwrite or append those sent with metrics.  Set the [tags] in the StatsD config file:<br/><br/>librato: {<br/>email:  "myemail@example.com",<br/>token:  "ca98e2bc23b1bfd0cbe9041e82d52ca4ac22cf3eab5a1c32",<br/>tags: { "os" : "ubuntu", "host" : "production-web-server-1", ... },<br/>alwaysIncludeTopLevelTags: true<br/>    } |
 
 ## Reducing published data for inactive stats
 
@@ -212,7 +213,18 @@ If you want to contribute:
 2. `yarn install`
 3. Hack away
 4. If you are adding new functionality, document it in the README
-5. Push the branch up to GitHub
-6. Send a pull request
+5. Add/modify unit tests where applicable. See [testing](#Testing) below.
+6. Push the branch up to GitHub
+7. Send a pull request
+
+### Testing
+Tests live in the [test/librato_tests.js](test/librato_tests.js) file.  You can add your tests cases there and to test your changes you need to install and run `nodeunit`.
+
+        npm install -g nodeunit
+
+To run the test just use the following command:
+
+        nodeunit tests/librato_tests.js
 
 [statsd]: https://github.com/etsy/statsd
+[tags]: #tags

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -60,6 +60,9 @@ var brokenMetrics = {};
 var tags = {};
 // Write to legacy
 var writeToLegacy = false;
+// Include top level (config) tags
+var alwaysIncludeTopLevelTags = false;
+
 var postPayload = function(options, proto, payload, retry) {
   if (logAll) {
     util.log('Sending Payload: ' + payload);
@@ -299,6 +302,13 @@ var flushStats = function libratoFlush(ts, metrics) {
     // Valid format for parsing tags out: global-prefix.name#tag1=value,tag2=value
     // NOTE: Name can include the source
     var vals = measureName.split('#');
+    // If we want to make sure our tags in the server config go with our measurements
+    if(alwaysIncludeTopLevelTags && tags) {
+      // Put the config ones in first, and then overwrite them with the metric ones
+      for(tag in tags) {
+        measure.tags[tag] = tags[tag];
+      }
+    }
     if (vals.length > 1) {
       // Found tags in the measureName. Parse them out and return the measureName without the tags.
       measureName = vals.shift();
@@ -507,6 +517,9 @@ exports.init = function libratoInit(startupTime, config, events, logger) {
     }
     if (config.librato.skipInternalMetrics != null) {
       skipInternalMetrics = config.librato.skipInternalMetrics;
+    }
+    if(config.librato.alwaysIncludeTopLevelTags != null) {
+      alwaysIncludeTopLevelTags = config.librato.alwaysIncludeTopLevelTags;
     }
     if (hostName == null) {
       var os = require('os');

--- a/lib/librato.js
+++ b/lib/librato.js
@@ -65,7 +65,7 @@ var alwaysIncludeTopLevelTags = false;
 
 var postPayload = function(options, proto, payload, retry) {
   if (logAll) {
-    util.log('Sending Payload: ' + payload);
+    util.log('DEBUG: librato-backend: Sending Payload: ' + payload);
   }
   var req = proto.request(options, function(res) {
     res.on('data', function(d) {
@@ -74,20 +74,20 @@ var postPayload = function(options, proto, payload, retry) {
         var errdata = 'HTTP ' + res.statusCode + ': ' + d;
         if (retry) {
           if (logAll) {
-            util.log('Failed to post to Librato: ' + errdata, 'LOG_ERR');
+            util.log('ERROR: librato-backend: Failed to post to Librato: ' + errdata);
           }
           setTimeout(function() {
             postPayload(options, proto, payload, false);
           }, retryDelaySecs * 1000);
         } else {
-          util.log('Failed to connect to Librato: ' + errdata, 'LOG_ERR');
+          util.log('ERROR: librato-backend: Failed to connect to Librato: ' + errdata);
         }
       }
       // Log 4xx errors
       if (Math.floor(res.statusCode / 100) == 4) {
         var errdata = 'HTTP ' + res.statusCode + ': ' + d;
         if (logAll) {
-          util.log('Failed to post to Librato: ' + errdata, 'LOG_ERR');
+          util.log('ERROR: librato-backend: Failed to post to Librato: ' + errdata);
         }
         if (/^application\/json/.test(res.headers['content-type'])) {
           var meta = JSON.parse(d);
@@ -100,7 +100,7 @@ var postPayload = function(options, proto, payload, retry) {
               if (field && !brokenMetrics[field]) {
                 brokenMetrics[field] = true;
                 if (logAll) {
-                  util.log('Placing metric \'' + field + '\' to stoplist until service restart', 'LOG_ERR');
+                  util.log('ERROR: librato-backend: Placing metric \'' + field + '\' to stoplist until service restart');
                 }
               }
             }
@@ -111,7 +111,7 @@ var postPayload = function(options, proto, payload, retry) {
   });
   req.setTimeout(postTimeoutSecs * 1000, function(request) {
     if (logAll) {
-      util.log('Timed out sending metrics to Librato', 'LOG_ERR');
+      util.log('DEBUG: librato-backend: Timed out sending metrics to Librato');
     }
     req.end();
   });
@@ -124,7 +124,7 @@ var postPayload = function(options, proto, payload, retry) {
         postPayload(options, proto, payload, false);
       }, retryDelaySecs * 1000);
     } else {
-      util.log('Failed to connect to Librato: ' + errdata, 'LOG_ERR');
+      util.log('ERROR: librato-backend: Failed to connect to Librato: ' + errdata);
     }
   });
 };
@@ -530,8 +530,8 @@ exports.init = function libratoInit(startupTime, config, events, logger) {
       try {
         TunnelFunc = require('https-proxy-agent');
       } catch (e) {
-        util.log('Cannot find module \'https-proxy-agent\'.', 'LOG_CRIT');
-        util.log('Make sure to run `npm install https-proxy-agent`.', 'LOG_CRIT');
+        util.log('ERROR: librato-backend: Cannot find module \'https-proxy-agent\'.');
+        util.log('ERROR: librato-backend: Make sure to run `npm install https-proxy-agent`.');
         return false;
       }
       tunnelAgent = new TunnelFunc(config.librato.proxy.uri);
@@ -565,7 +565,7 @@ exports.init = function libratoInit(startupTime, config, events, logger) {
     }
   }
   if (!email || !token) {
-    util.log('Invalid configuration for Librato Metrics backend', 'LOG_CRIT');
+    util.log('ERROR: Invalid configuration for Librato Metrics backend');
     return false;
   }
   flushInterval = config.flushInterval;


### PR DESCRIPTION
This feature came out from us wanting to be able to send a set of tags from our various environments that have their own statsd backends as well as metrics tags.  

This enables us to have the same metric names and be able to filter those streams by these tags which is a very powerful and useful feature for us.  In this PR there is a new setting `alwaysIncludeTopLevelTags` which will enable this functionality.  It is disabled by default so the current behavior still stays the same.

This was written and tested given the assumption that the backed should give precedence to the metric for a given tag.  This means that if the tag is set in the backend configuration and a metric uses that tag, it will be overwritten by what is sent in with the metric.

For example:

Librato backend configuration:

```js
{
  "librato" : {
    "tags": { "environment" : "dev", "cluster" : "some-cloud-dev" }
  }
}
```

If the statsd client sends:
```
metric.name#tag1=value,tag2=value:value
```

With the current behavior the backend creates the following measurement name:
```
metric.name#tag1=value,tag2=value:value
```

With this new feature enabled the measurement name that the backend creates is:
```
metric.name#environment=dev,cluster=some-cloud-dev,tag1=value,tag2=value:value
```

**Note the comment about precedence.**  

If the Librato backend configuration is:

```js
{
  "librato" : {
     // if this is set it is turned into a tag in the backend (existing behavior)
     // it overwrites the value for this tag if it was set before (existing behavior) 
    "host": "statsd-dev",
    "tags": { "environment" : "dev", "cluster" : "some-cloud-dev" }
  }
}

```
If the statsd client sends:
```
metric.name#host=some-server,tag1=value:value
```

With this new feature enabled the measurement name that the backend creates is:
```
metric.name#host=some-server,environment=dev,cluster=some-cloud-dev,tag1=value:value
```
