### PR TITLE
Logging whole response in debug mode

### DIFF
--- a/lib/librato.js
+++ b/lib/librato.js
@@ -66,6 +66,9 @@ var postPayload = function(options, proto, payload, retry) {
   }
   var req = proto.request(options, function(res) {
     res.on('data', function(d) {
+       if (logAll) {
+        util.log('Response: ' + d);
+      }
       // Retry 5xx codes
       if (Math.floor(res.statusCode / 100) == 5) {
         var errdata = 'HTTP ' + res.statusCode + ': ' + d;


### PR DESCRIPTION
Because some other errors might happen than the one handled (stoplist). Example, if the tag values have an invalid format, the response is something like:

```
{"measurements":{"summary":{"total":174,"accepted":78,"failed":96,"filtered":0}},"errors":[{"param":"tag_value","value":"41454@127_0_0_1","reason":"Invalid format"}]}
```

So it would be nice to log the whole response in debug mode to avoid discarding important failures.