### PR TITLE
Add example statsd path for clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ publishes stats to [Librato](https://metrics.librato.com).
 
 ## Installation
 
-    $ cd /path/to/statsd
+    $ cd /path/to/statsd  # e.g. /usr/lib/node_modules/statsd
     $ npm install statsd-librato-backend
 
 ## Configuration


### PR DESCRIPTION
Thanks for making this plugin!

It took me a while to realize `/path/to/statsd` was looking for the `node_modules` folder, not the path to a `statsd` executable or something, so I've added a comment that clarifies it a bit by mentioning the default install path. Another option might be to just say `cd /path/to/node_modules/statsd` or something, if you think that's better?